### PR TITLE
Feat/unified builder and store traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Nothing yet
+- Unified cache builder (`CacheBuilder`) with support for all eviction policies (FIFO, LRU, LRU-K, LFU, HeapLFU, 2Q).
+- New 2Q eviction policy (`TwoQCore`) with configurable probation/protected queue ratios.
+- `ConcurrentStoreRead` trait for read-only concurrent store operations.
+- `StoreFactory` and `ConcurrentStoreFactory` traits for creating store instances.
 
 ### Changed
-- Nothing yet
-
-### Deprecated
-- Nothing yet
+- Refactored store traits to separate single-threaded and concurrent ownership models:
+  - `StoreCore`/`StoreMut` now use direct value ownership (`&V`, `V`) for zero-overhead single-threaded access.
+  - `ConcurrentStore` uses `Arc<V>` for safe shared ownership across threads.
+- `HashMapStore` and `SlabStore` now store values directly (not `Arc`-wrapped) for single-threaded use.
+- `HandleStore` and `WeightStore` no longer implement generic store traits; they expose specialized `Arc<V>` APIs directly.
+- All cache policies updated to work with the new trait structure.
 
 ### Removed
-- Nothing yet
-
-### Fixed
-- Nothing yet
-
-### Security
-- Nothing yet
+- `StoreEvictionHook` struct (eviction recording moved to direct method calls).
+- `#[must_use]` attributes on `try_insert` methods (redundant with `Result`).
 
 ## [0.1.0-alpha] - 2026-01-13
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,275 @@
+//! Unified cache builder for all eviction policies.
+//!
+//! Provides a simple API to create caches with different eviction policies
+//! while hiding the internal implementation details (like `Arc<V>` wrapping).
+//!
+//! ## Example
+//!
+//! ```rust
+//! use cachekit::builder::{CacheBuilder, CachePolicy};
+//!
+//! let mut cache = CacheBuilder::new(100).build::<u64, String>(CachePolicy::Lru);
+//! cache.insert(1, "hello".to_string());
+//! assert_eq!(cache.get(&1), Some(&"hello".to_string()));
+//! ```
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use crate::policy::fifo::FifoCache;
+use crate::policy::heap_lfu::HeapLfuCache;
+use crate::policy::lfu::LfuCache;
+use crate::policy::lru::LruCore;
+use crate::policy::lru_k::LrukCache;
+use crate::policy::two_q::TwoQCore;
+use crate::traits::CoreCache;
+
+/// Available cache eviction policies.
+#[derive(Debug, Clone)]
+pub enum CachePolicy {
+    /// First In, First Out eviction.
+    Fifo,
+    /// Least Recently Used eviction.
+    Lru,
+    /// LRU-K policy with configurable K value (number of accesses to track).
+    LruK { k: usize },
+    /// Least Frequently Used eviction (bucket-based).
+    Lfu,
+    /// Least Frequently Used eviction (heap-based, requires `K: Ord`).
+    HeapLfu,
+    /// 2Q policy with configurable probation fraction.
+    TwoQ { probation_frac: f64 },
+}
+
+/// Unified cache wrapper that provides a consistent API regardless of policy.
+pub struct Cache<K, V>
+where
+    K: Copy + Eq + Hash + Ord,
+    V: Clone + Debug,
+{
+    inner: CacheInner<K, V>,
+}
+
+enum CacheInner<K, V>
+where
+    K: Copy + Eq + Hash + Ord,
+    V: Clone + Debug,
+{
+    Fifo(FifoCache<K, V>),
+    Lru(LruCore<K, V>),
+    LruK(LrukCache<K, V>),
+    Lfu(LfuCache<K, V>),
+    HeapLfu(HeapLfuCache<K, V>),
+    TwoQ(TwoQCore<K, V>),
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Copy + Eq + Hash + Ord,
+    V: Clone + Debug,
+{
+    /// Insert a key-value pair. Returns the previous value if the key existed.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match &mut self.inner {
+            CacheInner::Fifo(fifo) => CoreCache::insert(fifo, key, value),
+            CacheInner::Lru(lru) => {
+                let arc_value = Arc::new(value);
+                lru.insert(key, arc_value)
+                    .map(|arc| Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone()))
+            },
+            CacheInner::LruK(lruk) => CoreCache::insert(lruk, key, value),
+            CacheInner::Lfu(lfu) => {
+                let arc_value = Arc::new(value);
+                lfu.insert(key, arc_value)
+                    .map(|arc| Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone()))
+            },
+            CacheInner::HeapLfu(heap_lfu) => {
+                let arc_value = Arc::new(value);
+                heap_lfu
+                    .insert(key, arc_value)
+                    .map(|arc| Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone()))
+            },
+            CacheInner::TwoQ(twoq) => CoreCache::insert(twoq, key, value),
+        }
+    }
+
+    /// Get a reference to a value by key.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        match &mut self.inner {
+            CacheInner::Fifo(fifo) => fifo.get(key),
+            CacheInner::Lru(lru) => lru.get(key).map(|arc| arc.as_ref()),
+            CacheInner::LruK(lruk) => lruk.get(key),
+            CacheInner::Lfu(lfu) => lfu.get(key).map(|arc| arc.as_ref()),
+            CacheInner::HeapLfu(heap_lfu) => heap_lfu.get(key).map(|arc| arc.as_ref()),
+            CacheInner::TwoQ(twoq) => twoq.get(key),
+        }
+    }
+
+    /// Check if a key exists.
+    pub fn contains(&self, key: &K) -> bool {
+        match &self.inner {
+            CacheInner::Fifo(fifo) => fifo.contains(key),
+            CacheInner::Lru(lru) => lru.contains(key),
+            CacheInner::LruK(lruk) => lruk.contains(key),
+            CacheInner::Lfu(lfu) => lfu.contains(key),
+            CacheInner::HeapLfu(heap_lfu) => heap_lfu.contains(key),
+            CacheInner::TwoQ(twoq) => twoq.contains(key),
+        }
+    }
+
+    /// Return the number of entries.
+    pub fn len(&self) -> usize {
+        match &self.inner {
+            CacheInner::Fifo(fifo) => CoreCache::len(fifo),
+            CacheInner::Lru(lru) => lru.len(),
+            CacheInner::LruK(lruk) => CoreCache::len(lruk),
+            CacheInner::Lfu(lfu) => lfu.len(),
+            CacheInner::HeapLfu(heap_lfu) => heap_lfu.len(),
+            CacheInner::TwoQ(twoq) => twoq.len(),
+        }
+    }
+
+    /// Check if the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return the maximum capacity.
+    pub fn capacity(&self) -> usize {
+        match &self.inner {
+            CacheInner::Fifo(fifo) => CoreCache::capacity(fifo),
+            CacheInner::Lru(lru) => lru.capacity(),
+            CacheInner::LruK(lruk) => CoreCache::capacity(lruk),
+            CacheInner::Lfu(lfu) => lfu.capacity(),
+            CacheInner::HeapLfu(heap_lfu) => heap_lfu.capacity(),
+            CacheInner::TwoQ(twoq) => twoq.capacity(),
+        }
+    }
+
+    /// Clear all entries.
+    pub fn clear(&mut self) {
+        match &mut self.inner {
+            CacheInner::Fifo(fifo) => fifo.clear(),
+            CacheInner::Lru(lru) => lru.clear(),
+            CacheInner::LruK(lruk) => lruk.clear(),
+            CacheInner::Lfu(lfu) => lfu.clear(),
+            CacheInner::HeapLfu(heap_lfu) => heap_lfu.clear(),
+            CacheInner::TwoQ(twoq) => twoq.clear(),
+        }
+    }
+}
+
+/// Builder for creating cache instances.
+pub struct CacheBuilder {
+    capacity: usize,
+}
+
+impl CacheBuilder {
+    /// Create a new cache builder with the specified capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self { capacity }
+    }
+
+    /// Build a cache with the specified policy.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `K`: Key type, must be `Copy + Eq + Hash + Ord`
+    /// - `V`: Value type, must be `Clone + Debug`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cachekit::builder::{CacheBuilder, CachePolicy};
+    ///
+    /// // LRU cache
+    /// let cache = CacheBuilder::new(100).build::<u64, String>(CachePolicy::Lru);
+    ///
+    /// // LRU-K with K=2
+    /// let cache = CacheBuilder::new(100).build::<u64, String>(CachePolicy::LruK { k: 2 });
+    ///
+    /// // 2Q with 25% probation
+    /// let cache = CacheBuilder::new(100).build::<u64, String>(CachePolicy::TwoQ { probation_frac: 0.25 });
+    /// ```
+    pub fn build<K, V>(self, policy: CachePolicy) -> Cache<K, V>
+    where
+        K: Copy + Eq + Hash + Ord,
+        V: Clone + Debug,
+    {
+        let inner = match policy {
+            CachePolicy::Fifo => CacheInner::Fifo(FifoCache::new(self.capacity)),
+            CachePolicy::Lru => CacheInner::Lru(LruCore::new(self.capacity)),
+            CachePolicy::LruK { k } => CacheInner::LruK(LrukCache::with_k(self.capacity, k)),
+            CachePolicy::Lfu => CacheInner::Lfu(LfuCache::new(self.capacity)),
+            CachePolicy::HeapLfu => CacheInner::HeapLfu(HeapLfuCache::new(self.capacity)),
+            CachePolicy::TwoQ { probation_frac } => {
+                CacheInner::TwoQ(TwoQCore::new(self.capacity, probation_frac))
+            },
+        };
+
+        Cache { inner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_policies_basic_ops() {
+        let policies = [
+            CachePolicy::Fifo,
+            CachePolicy::Lru,
+            CachePolicy::LruK { k: 2 },
+            CachePolicy::Lfu,
+            CachePolicy::HeapLfu,
+            CachePolicy::TwoQ {
+                probation_frac: 0.25,
+            },
+        ];
+
+        for policy in policies {
+            let mut cache = CacheBuilder::new(10).build::<u64, String>(policy.clone());
+
+            // Insert
+            assert_eq!(cache.insert(1, "one".to_string()), None);
+            assert_eq!(cache.insert(2, "two".to_string()), None);
+
+            // Get
+            assert_eq!(cache.get(&1), Some(&"one".to_string()));
+            assert_eq!(cache.get(&2), Some(&"two".to_string()));
+            assert_eq!(cache.get(&3), None);
+
+            // Contains
+            assert!(cache.contains(&1));
+            assert!(!cache.contains(&99));
+
+            // Len
+            assert_eq!(cache.len(), 2);
+            assert!(!cache.is_empty());
+
+            // Update
+            assert_eq!(cache.insert(1, "ONE".to_string()), Some("one".to_string()));
+            assert_eq!(cache.get(&1), Some(&"ONE".to_string()));
+
+            // Clear
+            cache.clear();
+            assert!(cache.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_capacity_enforcement() {
+        let mut cache = CacheBuilder::new(2).build::<u64, String>(CachePolicy::Lru);
+
+        cache.insert(1, "one".to_string());
+        cache.insert(2, "two".to_string());
+        cache.insert(3, "three".to_string()); // Should evict key 1
+
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.contains(&1)); // Evicted
+        assert!(cache.contains(&2));
+        assert!(cache.contains(&3));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod store;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 
+pub mod builder;
 pub mod prelude;
 pub mod traits;

--- a/src/policy/heap_lfu.rs
+++ b/src/policy/heap_lfu.rs
@@ -259,7 +259,7 @@ pub struct HeapLfuCache<K, V>
 where
     K: Eq + Hash + Clone + Ord,
 {
-    store: HashMapStore<K, V>,
+    store: HashMapStore<K, Arc<V>>,
     frequencies: HashMap<K, u64>,
     // Min-heap: smallest frequency first
     // Reverse wrapper converts max-heap to min-heap
@@ -432,7 +432,7 @@ where
             // Add new frequency entry to heap (old entry becomes stale)
             self.add_to_heap(key, new_freq);
 
-            self.store.get_ref(key)
+            self.store.get(key)
         } else {
             None
         }
@@ -511,7 +511,7 @@ where
         // Find a key with the minimum frequency
         for (key, &freq) in &self.frequencies {
             if freq == min_freq {
-                return self.store.peek_ref(key).map(|value| (key, value));
+                return self.store.peek(key).map(|value| (key, value));
             }
         }
 

--- a/src/policy/lfu.rs
+++ b/src/policy/lfu.rs
@@ -335,7 +335,7 @@ pub struct LfuCache<K, V>
 where
     K: Eq + Hash + Clone,
 {
-    store: HashMapStore<K, V>,
+    store: HashMapStore<K, Arc<V>>,
     buckets: FrequencyBuckets<K>,
     #[cfg(feature = "metrics")]
     metrics: LfuMetrics,
@@ -350,7 +350,7 @@ pub struct LFUHandleCache<H, V>
 where
     H: Eq + Hash + Copy,
 {
-    store: HashMapStore<H, V>,
+    store: HashMapStore<H, Arc<V>>,
     buckets: FrequencyBucketsHandle<H>,
     #[cfg(feature = "metrics")]
     metrics: LfuMetrics,
@@ -527,7 +527,7 @@ where
         if !self.buckets.contains(key) {
             #[cfg(feature = "metrics")]
             self.metrics.record_get_miss();
-            let _ = self.store.get_ref(key);
+            let _ = self.store.get(key);
             return None;
         }
 
@@ -536,7 +536,7 @@ where
         #[cfg(feature = "metrics")]
         self.metrics.record_get_hit();
 
-        self.store.get_ref(key)
+        self.store.get(key)
     }
 
     fn contains(&self, key: &K) -> bool {
@@ -604,7 +604,7 @@ where
         if !self.buckets.contains(handle) {
             #[cfg(feature = "metrics")]
             self.metrics.record_get_miss();
-            let _ = self.store.get_ref(handle);
+            let _ = self.store.get(handle);
             return None;
         }
 
@@ -613,7 +613,7 @@ where
         #[cfg(feature = "metrics")]
         self.metrics.record_get_hit();
 
-        self.store.get_ref(handle)
+        self.store.get(handle)
     }
 
     fn contains(&self, handle: &H) -> bool {
@@ -679,7 +679,7 @@ where
         (&self.metrics).record_peek_lfu_call();
 
         let (key, _freq) = self.buckets.peek_min()?;
-        let value = self.store.peek_ref(key)?;
+        let value = self.store.peek(key)?;
 
         #[cfg(feature = "metrics")]
         (&self.metrics).record_peek_lfu_found();
@@ -750,7 +750,7 @@ where
         (&self.metrics).record_peek_lfu_call();
 
         let (handle, _freq) = self.buckets.peek_min_ref()?;
-        let value = self.store.peek_ref(handle)?;
+        let value = self.store.peek(handle)?;
 
         #[cfg(feature = "metrics")]
         (&self.metrics).record_peek_lfu_found();

--- a/src/policy/lru_k.rs
+++ b/src/policy/lru_k.rs
@@ -301,7 +301,7 @@ where
     K: Eq + Hash + Clone,
 {
     k: usize,
-    store: HashMapStore<K, V>,
+    store: HashMapStore<K, Arc<V>>,
     entries: SlotArena<Entry<K>>,
     index: HashMap<K, SlotId>,
     cold: IntrusiveList<SlotId>,
@@ -513,7 +513,7 @@ where
             None => {
                 #[cfg(feature = "metrics")]
                 self.metrics.record_get_miss();
-                let _ = self.store.get_ref(key);
+                let _ = self.store.get(key);
                 return None;
             },
         };
@@ -525,7 +525,7 @@ where
         #[cfg(feature = "metrics")]
         self.metrics.record_get_hit();
 
-        self.store.get_ref(key).map(|value| value.as_ref())
+        self.store.get(key).map(|value| value.as_ref())
     }
 
     fn contains(&self, key: &K) -> bool {
@@ -595,7 +595,7 @@ where
 
         let idx = self.peek_candidate()?;
         let entry = self.entries.get(idx)?;
-        let value = self.store.peek_ref(&entry.key)?;
+        let value = self.store.peek(&entry.key)?;
 
         #[cfg(feature = "metrics")]
         (&self.metrics).record_peek_lru_k_found();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -3,3 +3,4 @@ pub mod heap_lfu;
 pub mod lfu;
 pub mod lru;
 pub mod lru_k;
+pub mod two_q;

--- a/src/policy/two_q.rs
+++ b/src/policy/two_q.rs
@@ -1,0 +1,239 @@
+use crate::ds::{IntrusiveList, SlotArena, SlotId};
+use crate::store::hashmap::HashMapStore;
+use crate::store::traits::{StoreCore, StoreMut};
+use std::collections::VecDeque;
+use std::hash::Hash;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum QueueKind {
+    Probation,
+    Protected,
+}
+
+#[derive(Debug)]
+struct Entry<K, V> {
+    key: K,
+    value: V,
+    queue: QueueKind,
+}
+
+#[derive(Debug)]
+pub struct LruQueue<T> {
+    list: IntrusiveList<T>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct TwoQWithGhost<K, V> {
+    core: TwoQCore<K, V>,
+    ghost_list: VecDeque<K>,
+    ghost_list_cap: usize,
+}
+
+#[derive(Debug)]
+pub struct TwoQCore<K, V> {
+    index: HashMapStore<K, SlotId>, // key → store id
+    store: SlotArena<Entry<K, V>>,
+
+    probation: IntrusiveList<SlotId>, // FIFO probation
+    protected: LruQueue<SlotId>,      // LRU protected
+
+    probation_cap: usize,
+    protected_cap: usize,
+}
+
+impl<T> Default for LruQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> LruQueue<T> {
+    pub fn new() -> Self {
+        Self {
+            list: IntrusiveList::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.list.len() == 0
+    }
+
+    pub fn insert(&mut self, id: T) -> SlotId {
+        // new item is most-recently-used
+        self.list.push_front(id)
+    }
+
+    pub fn touch(&mut self, id: SlotId) -> bool {
+        // move accessed item to MRU position
+        self.list.move_to_front(id)
+    }
+
+    pub fn evict(&mut self) -> Option<T> {
+        // remove least-recently-used
+        self.list.pop_back()
+    }
+
+    pub fn remove(&mut self, id: SlotId) -> Option<T> {
+        self.list.remove(id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    pub fn push_front(&mut self, id: T) -> SlotId {
+        self.list.push_front(id)
+    }
+
+    pub fn move_to_front(&mut self, id: SlotId) -> bool {
+        self.list.move_to_front(id)
+    }
+    pub fn pop_back(&mut self) -> Option<T> {
+        self.list.pop_back()
+    }
+}
+
+impl<K, V> TwoQCore<K, V>
+where
+    K: Clone + Eq + Hash,
+{
+    pub fn new(protected_cap: usize, a1_frac: f64) -> Self {
+        let probation_cap = (protected_cap as f64 * a1_frac) as usize;
+
+        Self {
+            index: HashMapStore::new(protected_cap),
+            store: SlotArena::new(),
+            probation: IntrusiveList::new(),
+            protected: LruQueue::new(),
+            probation_cap,
+            protected_cap,
+        }
+    }
+
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        let id = self.index.get(key)?;
+
+        let queue = self.store.get(*id)?.queue;
+        match queue {
+            QueueKind::Probation => {
+                self.probation.remove(*id);
+                self.probation.push_front(*id);
+                if let Some(e) = self.store.get_mut(*id) {
+                    e.queue = QueueKind::Protected;
+                }
+            },
+            QueueKind::Protected => {
+                self.protected.move_to_front(*id);
+            },
+        }
+
+        self.store.get(*id).map(|e| &e.value)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        if let Some(id) = self.index.get(&key) {
+            if let Some(e) = self.store.get_mut(*id) {
+                e.value = value;
+            }
+            return;
+        }
+
+        let entry = Entry {
+            key: key.clone(),
+            value,
+            queue: QueueKind::Probation,
+        };
+        let id = self.store.insert(entry);
+
+        self.index
+            .try_insert(key, id)
+            .expect("Failed to insert entry");
+        self.probation.push_back(id);
+
+        self.evict_if_needed();
+    }
+
+    fn evict_if_needed(&mut self) {
+        while self.len() > self.protected_cap {
+            if self.probation.len() > self.probation_cap {
+                if let Some(id) = self.probation.pop_front() {
+                    self.remove_id(id);
+                }
+            } else if let Some(id) = self.protected.pop_back() {
+                self.remove_id(id);
+            }
+        }
+    }
+
+    fn remove_id(&mut self, id: SlotId) {
+        if let Some(entry) = self.store.remove(id) {
+            self.index.remove(&entry.key);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.index.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index.len() == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.protected_cap
+    }
+
+    pub fn contains(&self, key: &K) -> bool {
+        self.index.contains(key)
+    }
+
+    pub fn clear(&mut self) {
+        self.index.clear();
+        self.store.clear();
+        self.probation.clear();
+        self.protected.list.clear();
+    }
+}
+
+impl<K, V> crate::traits::CoreCache<K, V> for TwoQCore<K, V>
+where
+    K: Clone + Eq + Hash,
+{
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        // Check if key exists - update in place
+        if let Some(id) = self.index.get(&key) {
+            if let Some(e) = self.store.get_mut(*id) {
+                let old = std::mem::replace(&mut e.value, value);
+                return Some(old);
+            }
+        }
+
+        // New insert
+        TwoQCore::insert(self, key, value);
+        None
+    }
+
+    fn get(&mut self, key: &K) -> Option<&V> {
+        TwoQCore::get(self, key)
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.index.contains(key)
+    }
+
+    fn len(&self) -> usize {
+        self.index.len()
+    }
+
+    fn capacity(&self) -> usize {
+        self.protected_cap
+    }
+
+    fn clear(&mut self) {
+        self.index.clear();
+        self.store.clear();
+        self.probation.clear();
+        self.protected.list.clear();
+    }
+}

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -3,9 +3,20 @@
 //! Stores focus on key/value ownership and lookup semantics, while policies
 //! manage eviction order and metadata. This keeps policy logic independent
 //! of how values are stored (e.g., HashMap, concurrent map, arena).
+//!
+//! ## Ownership Model
+//!
+//! Single-threaded stores (`StoreCore` + `StoreMut`) use direct ownership:
+//! - Store owns `K` and `V` after insertion
+//! - `get` returns `&V` (zero overhead)
+//! - `remove` returns owned `V`
+//!
+//! Concurrent stores (`ConcurrentStore`) use shared ownership:
+//! - Store holds `Arc<V>` internally
+//! - `get` returns `Arc<V>` (can outlive the lock)
+//! - Required because references can't outlive lock guards
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Snapshot of store-level metrics.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -18,32 +29,66 @@ pub struct StoreMetrics {
     pub evictions: u64,
 }
 
-/// Eviction hook for policy code to update store-level eviction metrics.
-#[derive(Debug, Default)]
-pub struct StoreEvictionHook {
-    evictions: AtomicU64,
-}
-
-impl StoreEvictionHook {
-    pub fn record_eviction(&self) {
-        self.evictions.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn metrics(&self) -> StoreMetrics {
-        StoreMetrics {
-            evictions: self.evictions.load(Ordering::Relaxed),
-            ..StoreMetrics::default()
-        }
-    }
-}
-
 /// Error returned when a store is at capacity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StoreFull;
 
-/// Core store operations common to all backends.
+// =============================================================================
+// Single-threaded store traits
+// =============================================================================
+
+/// Read-only store operations for single-threaded backends.
+///
+/// Returns borrowed references to avoid allocation overhead.
 pub trait StoreCore<K, V> {
-    /// Fetch a value by key.
+    /// Fetch a reference to a value by key.
+    fn get(&self, key: &K) -> Option<&V>;
+
+    /// Check if a key exists.
+    fn contains(&self, key: &K) -> bool;
+
+    /// Current number of entries.
+    fn len(&self) -> usize;
+
+    /// Check if the store is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Maximum entries allowed.
+    fn capacity(&self) -> usize;
+
+    /// Snapshot the store's current metrics.
+    fn metrics(&self) -> StoreMetrics {
+        StoreMetrics::default()
+    }
+}
+
+/// Mutable store operations for single-threaded backends.
+///
+/// Takes and returns owned values directly—no `Arc` overhead.
+pub trait StoreMut<K, V>: StoreCore<K, V> {
+    /// Insert or update a value. Returns the previous value if present.
+    ///
+    /// Returns `StoreFull` if at capacity and inserting a new key.
+    fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreFull>;
+
+    /// Remove a value by key, returning the owned value.
+    fn remove(&mut self, key: &K) -> Option<V>;
+
+    /// Remove all entries.
+    fn clear(&mut self);
+}
+
+// =============================================================================
+// Concurrent store traits
+// =============================================================================
+
+/// Read-only store operations for concurrent backends.
+///
+/// Returns `Arc<V>` because references can't outlive lock guards.
+pub trait ConcurrentStoreRead<K, V>: Send + Sync {
+    /// Fetch a shared reference to a value by key.
     fn get(&self, key: &K) -> Option<Arc<V>>;
 
     /// Check if a key exists.
@@ -57,34 +102,21 @@ pub trait StoreCore<K, V> {
         self.len() == 0
     }
 
-    /// Maximum entries allowed by the policy.
+    /// Maximum entries allowed.
     fn capacity(&self) -> usize;
 
     /// Snapshot the store's current metrics.
     fn metrics(&self) -> StoreMetrics {
         StoreMetrics::default()
     }
-
-    /// Record that the policy evicted an entry.
-    fn record_eviction(&self) {}
-}
-
-/// Mutable store operations for single-threaded backends.
-pub trait StoreMut<K, V>: StoreCore<K, V> {
-    /// Insert or update a value. Returns the previous value if present.
-    /// Returns `StoreFull` if at capacity and inserting a new key.
-    fn try_insert(&mut self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull>;
-
-    /// Remove a value by key.
-    fn remove(&mut self, key: &K) -> Option<Arc<V>>;
-
-    /// Remove all entries.
-    fn clear(&mut self);
 }
 
 /// Mutable store operations for concurrent backends (interior mutability).
-pub trait ConcurrentStore<K, V>: StoreCore<K, V> + Send + Sync {
+///
+/// Uses `Arc<V>` for values since multiple threads may hold references.
+pub trait ConcurrentStore<K, V>: ConcurrentStoreRead<K, V> {
     /// Insert or update a value. Returns the previous value if present.
+    ///
     /// Returns `StoreFull` if at capacity and inserting a new key.
     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull>;
 
@@ -95,9 +127,21 @@ pub trait ConcurrentStore<K, V>: StoreCore<K, V> + Send + Sync {
     fn clear(&self);
 }
 
-/// Factory trait for creating store instances.
+// =============================================================================
+// Factory traits
+// =============================================================================
+
+/// Factory trait for creating single-threaded store instances.
 pub trait StoreFactory<K, V> {
     type Store: StoreCore<K, V>;
+
+    /// Create a new store with the specified capacity.
+    fn create(capacity: usize) -> Self::Store;
+}
+
+/// Factory trait for creating concurrent store instances.
+pub trait ConcurrentStoreFactory<K, V> {
+    type Store: ConcurrentStore<K, V>;
 
     /// Create a new store with the specified capacity.
     fn create(capacity: usize) -> Self::Store;


### PR DESCRIPTION
# Add unified cache builder and refactor store traits

## Description

Introduces a unified cache builder that provides a consistent API across all eviction policies, hiding internal implementation details like `Arc` wrapping from users. Also refactors store traits to separate single-threaded (direct ownership) from concurrent (`Arc`-based) access patterns.

**Key changes:**
- `CacheBuilder` with support for FIFO, LRU, LRU-K, LFU, HeapLFU, and 2Q policies
- New 2Q eviction policy (`TwoQCore`) with configurable probation/protected queue ratios
- Store traits split into `StoreCore`/`StoreMut` (direct ownership) and `ConcurrentStore` (`Arc<V>`)
- Zero `Arc` overhead for single-threaded cache usage

## Related Issue

N/A - Internal architecture improvement

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test addition or modification

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test environment:**
- OS: macOS
- Rust version: stable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have added tests for my changes
- [x] All new and existing tests pass (`cargo test`)
- [x] I have updated the documentation as needed
- [x] I have added an entry to CHANGELOG.md (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

### Breaking changes

- `StoreCore::get` now returns `Option<&V>` instead of `Option<Arc<V>>`
- `StoreMut::try_insert` and `remove` now take/return `V` instead of `Arc<V>`
- `HandleStore` and `WeightStore` no longer implement generic store traits

### Migration guide

For single-threaded caches, remove `Arc::new()` wrapping on insert and `.as_ref()` on get - values are now owned directly.

For concurrent caches, use `ConcurrentStore` trait which retains the `Arc<V>` API.
