### PR TITLE
Add docstrings with examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --verbose
+      - name: Run doc tests
+        run: cargo test --doc
       - name: Run tests
         run: cargo test --all-features --all-targets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ConcurrentStoreRead` trait for read-only concurrent store operations.
 - `StoreFactory` and `ConcurrentStoreFactory` traits for creating store instances.
 
+### Documentation
+- Complete documentation for `src/policy/lru_k.rs`:
+  - Architecture diagram showing cache layout and K-distance calculation.
+  - Scan resistance explanation with before/after diagrams.
+  - Docstrings with examples for `LrukCache`, `new()`, `with_k()`, and all trait methods.
+  - Private method docstrings with complexity notes.
+- Complete documentation for `src/policy/lfu.rs`:
+  - Architecture diagram showing frequency buckets and eviction flow.
+  - LFU vs LRU comparison diagram.
+  - Docstrings with examples for `LfuCache`, `LFUHandleCache`, and all public methods.
+  - Batch operation examples (`insert_batch`, `remove_batch`, `touch_batch`).
+  - Metrics snapshot documentation.
+- Complete documentation for `src/policy/heap_lfu.rs`:
+  - Architecture diagram showing min-heap structure and stale entry handling.
+  - Standard LFU vs Heap LFU performance comparison.
+  - Docstrings with examples for `HeapLfuCache` and all public methods.
+  - Private method docstrings explaining lazy deletion and heap rebuild strategy.
+
 ### Changed
 - Refactored store traits to separate single-threaded and concurrent ownership models:
   - `StoreCore`/`StoreMut` now use direct value ownership (`&V`, `V`) for zero-overhead single-threaded access.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,24 +2,30 @@
 
 Welcome to the CacheKit documentation site.
 
-## Getting started
+## Getting Started
 
-- [Design overview](design.md)
-- [Stores](stores/README.md)
-- [Policy overview](policies/README.md)
-- [Policy roadmap](policies/roadmap/README.md)
-- [Policy data structures](policy-ds/README.md)
-- [Policy survey and tradeoffs](policies.md)
-- [Benchmarks](benchmarks.md)
+- [Integration guide](integration.md) — CacheBuilder API, policy selection, thread safety
+- [Design overview](design.md) — Architectural decisions and performance principles
 
-## Release and maintenance
+## Policies
+
+- [Policy overview](policies/README.md) — Implemented policies
+- [Policy roadmap](policies/roadmap/README.md) — Future policies
+- [Policy survey and tradeoffs](policies.md) — Comparison and selection guide
+
+## Internals
+
+- [Stores](stores/README.md) — Storage backends
+- [Policy data structures](policy-ds/README.md) — Implementation details
+- [Benchmarks](benchmarks.md) — Performance benchmarks
+
+## Observability
+
+- [Metrics](metrics.md) — Metrics integration and usage
+
+## Release and Maintenance
 
 - [Release checklist](release-checklist.md)
 - [Releasing CacheKit](releasing.md)
 - [CI/CD release cycle](ci-cd-release-cycle.md)
 - [Documentation style guide](style-guide.md)
-
-## Misc
-
-- [Integration notes](integration.md)
-- [Metrics notes](metrics.md)

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,216 @@
+# Integration Guide
+
+This guide covers how to integrate CacheKit into your application.
+
+## CacheBuilder API
+
+The `CacheBuilder` provides a unified, ergonomic API for creating caches with any eviction policy. It hides internal implementation details (like `Arc<V>` wrapping) and provides a consistent interface.
+
+### Basic Usage
+
+```rust
+use cachekit::builder::{CacheBuilder, CachePolicy};
+
+// Create a cache with the builder
+let mut cache = CacheBuilder::new(1000).build::<u64, String>(CachePolicy::Lru);
+
+// Standard operations
+cache.insert(1, "value".to_string());
+let value = cache.get(&1);
+cache.clear();
+```
+
+### Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              CacheBuilder                                   │
+│                                                                             │
+│   CacheBuilder::new(capacity)                                               │
+│         │                                                                   │
+│         ▼                                                                   │
+│   .build::<K, V>(policy)                                                    │
+│         │                                                                   │
+│         ├─── CachePolicy::Fifo ────► FifoCache<K, V>                       │
+│         ├─── CachePolicy::Lru ─────► LruCore<K, V>                         │
+│         ├─── CachePolicy::LruK ────► LrukCache<K, V>                       │
+│         ├─── CachePolicy::Lfu ─────► LfuCache<K, V>                        │
+│         ├─── CachePolicy::HeapLfu ─► HeapLfuCache<K, V>                    │
+│         └─── CachePolicy::TwoQ ────► TwoQCore<K, V>                        │
+│                                                                             │
+│         ▼                                                                   │
+│   Cache<K, V>  (unified wrapper)                                            │
+│   ┌─────────────────────────────────────────────────────────────────────┐   │
+│   │  .insert(key, value)  → Option<V>                                   │   │
+│   │  .get(&key)           → Option<&V>                                  │   │
+│   │  .contains(&key)      → bool                                        │   │
+│   │  .len() / .is_empty() → usize / bool                                │   │
+│   │  .capacity()          → usize                                       │   │
+│   │  .clear()                                                           │   │
+│   └─────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Type Constraints
+
+The `Cache<K, V>` wrapper requires:
+
+| Type | Bounds | Reason |
+|------|--------|--------|
+| `K` | `Copy + Eq + Hash + Ord` | Key indexing, heap ordering (HeapLFU) |
+| `V` | `Clone + Debug` | Value extraction, debug formatting |
+
+### Policy Selection
+
+| Policy | Use Case | Trade-offs |
+|--------|----------|------------|
+| `Fifo` | Simple, predictable eviction | No recency/frequency tracking |
+| `Lru` | Temporal locality | Vulnerable to scans |
+| `LruK { k }` | Scan resistance | Extra memory for history |
+| `Lfu` | Stable hot spots | Slow to adapt to changes |
+| `HeapLfu` | Large caches, frequent evictions | O(log n) eviction |
+| `TwoQ { probation_frac }` | Mixed workloads | Two-queue overhead |
+
+## Direct Policy Access
+
+For advanced use cases requiring policy-specific operations (e.g., `touch()`, `frequency()`, `k_distance()`), use the underlying cache implementations directly.
+
+### Trait Hierarchy
+
+```text
+                     CoreCache<K, V>
+                           │
+           ┌───────────────┴───────────────┐
+           │                               │
+  FifoCacheTrait<K, V>            MutableCache<K, V>
+                                           │
+                    ┌──────────────────────┼──────────────────────┐
+                    │                      │                      │
+           LruCacheTrait<K, V>    LfuCacheTrait<K, V>    LrukCacheTrait<K, V>
+```
+
+### Example: LRU-specific Operations
+
+```rust
+use std::sync::Arc;
+use cachekit::policy::lru::LruCore;
+use cachekit::traits::{CoreCache, LruCacheTrait};
+
+let mut cache: LruCore<u64, &str> = LruCore::new(100);
+cache.insert(1, Arc::new("first"));
+cache.insert(2, Arc::new("second"));
+
+// Touch to mark as recently used
+cache.touch(&1);
+
+// Peek at LRU entry
+if let Some((key, _)) = cache.peek_lru() {
+    println!("LRU key: {}", key);
+}
+
+// Pop LRU entry
+let evicted = cache.pop_lru();
+```
+
+### Example: LFU-specific Operations
+
+```rust
+use std::sync::Arc;
+use cachekit::policy::lfu::LfuCache;
+use cachekit::traits::{CoreCache, LfuCacheTrait};
+
+let mut cache: LfuCache<u64, &str> = LfuCache::new(100);
+cache.insert(1, Arc::new("value"));
+
+// Check frequency
+println!("Frequency: {:?}", cache.frequency(&1));
+
+// Boost frequency without accessing value
+cache.increment_frequency(&1);
+
+// Reset frequency (demote hot entry)
+cache.reset_frequency(&1);
+```
+
+### Example: LRU-K-specific Operations
+
+```rust
+use cachekit::policy::lru_k::LrukCache;
+use cachekit::traits::{CoreCache, LrukCacheTrait};
+
+// Create LRU-2 cache
+let mut cache = LrukCache::with_k(100, 2);
+cache.insert(1, "value");
+
+// Check access count and K-distance
+println!("Access count: {:?}", cache.access_count(&1));
+println!("K-distance: {:?}", cache.k_distance(&1));
+
+// Touch to record access
+cache.touch(&1);
+```
+
+## Thread Safety
+
+Individual cache implementations are **NOT** thread-safe by default. For concurrent access:
+
+### Option 1: External Synchronization
+
+```rust
+use std::sync::{Arc, RwLock};
+use cachekit::policy::lru_k::LrukCache;
+use cachekit::traits::CoreCache;
+
+let cache = Arc::new(RwLock::new(LrukCache::<u64, String>::new(100)));
+
+// Read access
+{
+    let guard = cache.read().unwrap();
+    let _ = guard.contains(&1);
+}
+
+// Write access
+{
+    let mut guard = cache.write().unwrap();
+    guard.insert(1, "value".to_string());
+}
+```
+
+### Option 2: Builder with External Lock
+
+```rust
+use std::sync::{Arc, Mutex};
+use cachekit::builder::{CacheBuilder, CachePolicy};
+
+let cache = Arc::new(Mutex::new(
+    CacheBuilder::new(100).build::<u64, String>(CachePolicy::Lru)
+));
+
+// Use from multiple threads
+let cache_clone = cache.clone();
+std::thread::spawn(move || {
+    let mut guard = cache_clone.lock().unwrap();
+    guard.insert(1, "value".to_string());
+});
+```
+
+## Metrics Integration
+
+When the `metrics` feature is enabled, caches expose metrics via `metrics_snapshot()`:
+
+```rust
+// Requires: cachekit = { ..., features = ["metrics"] }
+use cachekit::policy::lru_k::LrukCache;
+
+let mut cache = LrukCache::<u64, String>::new(100);
+cache.insert(1, "value".to_string());
+cache.get(&1);
+
+#[cfg(feature = "metrics")]
+{
+    let metrics = cache.metrics_snapshot();
+    println!("Hits: {}", metrics.hits());
+    println!("Misses: {}", metrics.misses());
+    println!("Hit rate: {:.2}%", metrics.hit_rate() * 100.0);
+}
+```

--- a/examples/basic_builder.rs
+++ b/examples/basic_builder.rs
@@ -1,0 +1,167 @@
+//! Example demonstrating the unified CacheBuilder API.
+//!
+//! Run with: cargo run --example basic_builder
+
+use cachekit::builder::{CacheBuilder, CachePolicy};
+
+fn main() {
+    println!("=== CacheBuilder Examples ===\n");
+
+    // Example 1: LRU Cache
+    println!("1. LRU Cache");
+    let mut lru = CacheBuilder::new(3).build::<u64, String>(CachePolicy::Lru);
+
+    lru.insert(1, "one".to_string());
+    lru.insert(2, "two".to_string());
+    lru.insert(3, "three".to_string());
+
+    // Access key 1 to make it MRU
+    lru.get(&1);
+
+    // Insert key 4, evicts LRU (key 2)
+    lru.insert(4, "four".to_string());
+
+    println!("   contains 1? {} (was accessed)", lru.contains(&1));
+    println!("   contains 2? {} (evicted as LRU)", lru.contains(&2));
+    println!("   contains 4? {} (just inserted)", lru.contains(&4));
+    println!();
+
+    // Example 2: FIFO Cache
+    println!("2. FIFO Cache");
+    let mut fifo = CacheBuilder::new(3).build::<u64, String>(CachePolicy::Fifo);
+
+    fifo.insert(1, "one".to_string());
+    fifo.insert(2, "two".to_string());
+    fifo.insert(3, "three".to_string());
+
+    // Access doesn't affect FIFO order
+    fifo.get(&1);
+
+    // Insert key 4, evicts oldest (key 1)
+    fifo.insert(4, "four".to_string());
+
+    println!("   contains 1? {} (evicted as oldest)", fifo.contains(&1));
+    println!("   contains 2? {} (still present)", fifo.contains(&2));
+    println!();
+
+    // Example 3: LRU-K Cache (scan-resistant)
+    println!("3. LRU-K Cache (K=2)");
+    let mut lru_k = CacheBuilder::new(3).build::<u64, String>(CachePolicy::LruK { k: 2 });
+
+    lru_k.insert(1, "one".to_string());
+    lru_k.insert(2, "two".to_string());
+    lru_k.insert(3, "three".to_string());
+
+    // Access key 1 twice (reaches K=2 threshold)
+    lru_k.get(&1);
+
+    // Insert key 4, evicts cold entry (key 2 or 3)
+    lru_k.insert(4, "four".to_string());
+
+    println!(
+        "   contains 1? {} (accessed twice, promoted)",
+        lru_k.contains(&1)
+    );
+    println!("   len: {}", lru_k.len());
+    println!();
+
+    // Example 4: LFU Cache
+    println!("4. LFU Cache");
+    let mut lfu = CacheBuilder::new(3).build::<u64, String>(CachePolicy::Lfu);
+
+    lfu.insert(1, "one".to_string());
+    lfu.insert(2, "two".to_string());
+    lfu.insert(3, "three".to_string());
+
+    // Access key 1 multiple times
+    lfu.get(&1);
+    lfu.get(&1);
+    lfu.get(&1);
+
+    // Insert key 4, evicts LFU (key 2 or 3)
+    lfu.insert(4, "four".to_string());
+
+    println!("   contains 1? {} (highest frequency)", lfu.contains(&1));
+    println!("   len: {}", lfu.len());
+    println!();
+
+    // Example 5: 2Q Cache
+    println!("5. 2Q Cache (25% probation)");
+    let mut two_q = CacheBuilder::new(4).build::<u64, String>(CachePolicy::TwoQ {
+        probation_frac: 0.25,
+    });
+
+    two_q.insert(1, "one".to_string());
+    two_q.insert(2, "two".to_string());
+    two_q.insert(3, "three".to_string());
+    two_q.insert(4, "four".to_string());
+
+    // Access to promote from probation to protected
+    two_q.get(&1);
+
+    println!("   capacity: {}", two_q.capacity());
+    println!("   len: {}", two_q.len());
+    println!();
+
+    // Example 6: Common operations
+    println!("6. Common Operations");
+    let mut cache = CacheBuilder::new(10).build::<u64, String>(CachePolicy::Lru);
+
+    // Insert and update
+    cache.insert(1, "original".to_string());
+    let old = cache.insert(1, "updated".to_string());
+    println!("   insert returned previous: {:?}", old);
+
+    // Get
+    if let Some(value) = cache.get(&1) {
+        println!("   get(&1): {}", value);
+    }
+
+    // Contains (doesn't update access order)
+    println!("   contains(&1): {}", cache.contains(&1));
+    println!("   contains(&99): {}", cache.contains(&99));
+
+    // Size
+    println!(
+        "   len: {}, capacity: {}, is_empty: {}",
+        cache.len(),
+        cache.capacity(),
+        cache.is_empty()
+    );
+
+    // Clear
+    cache.clear();
+    println!("   after clear - is_empty: {}", cache.is_empty());
+}
+
+// Expected output:
+// === CacheBuilder Examples ===
+//
+// 1. LRU Cache
+//    contains 1? true (was accessed)
+//    contains 2? false (evicted as LRU)
+//    contains 4? true (just inserted)
+//
+// 2. FIFO Cache
+//    contains 1? false (evicted as oldest)
+//    contains 2? true (still present)
+//
+// 3. LRU-K Cache (K=2)
+//    contains 1? true (accessed twice, promoted)
+//    len: 3
+//
+// 4. LFU Cache
+//    contains 1? true (highest frequency)
+//    len: 3
+//
+// 5. 2Q Cache (25% probation)
+//    capacity: 4
+//    len: 4
+//
+// 6. Common Operations
+//    insert returned previous: Some("original")
+//    get(&1): updated
+//    contains(&1): true
+//    contains(&99): false
+//    len: 1, capacity: 10, is_empty: false
+//    after clear - is_empty: true

--- a/examples/basic_two_q.rs
+++ b/examples/basic_two_q.rs
@@ -1,0 +1,120 @@
+//! Example demonstrating the 2Q (Two-Queue) cache policy.
+//!
+//! 2Q uses two queues: a probation queue for new entries and a protected queue
+//! for entries that have been accessed more than once. This provides scan
+//! resistance similar to LRU-K.
+//!
+//! Run with: cargo run --example basic_two_q
+
+use cachekit::builder::{CacheBuilder, CachePolicy};
+
+fn main() {
+    println!("=== 2Q Cache Example ===\n");
+
+    // Create a 2Q cache with capacity 10 and 25% probation queue
+    // - Probation queue: ~2-3 slots (for new items, FIFO eviction)
+    // - Protected queue: ~7-8 slots (for frequently accessed items, LRU eviction)
+    let mut cache = CacheBuilder::new(10).build::<u64, String>(CachePolicy::TwoQ {
+        probation_frac: 0.25,
+    });
+
+    println!("Created 2Q cache: capacity={}\n", cache.capacity());
+
+    // Insert items (all start in probation queue)
+    for i in 1..=5 {
+        cache.insert(i, format!("value-{}", i));
+    }
+    println!("Inserted keys 1-5 (all in probation queue)");
+    println!("  len: {}", cache.len());
+
+    // Access keys 1 and 2 to promote them from probation to protected
+    cache.get(&1);
+    cache.get(&2);
+    println!("\nAccessed keys 1 and 2 (promoted to protected queue)");
+
+    // Insert more items to fill the cache
+    for i in 6..=10 {
+        cache.insert(i, format!("value-{}", i));
+    }
+    println!("Inserted keys 6-10");
+    println!("  len: {}", cache.len());
+
+    // Now insert more items - probation queue items should be evicted first
+    cache.insert(11, "value-11".to_string());
+    cache.insert(12, "value-12".to_string());
+
+    println!("\nAfter inserting keys 11, 12:");
+    println!(
+        "  contains 1? {} (was promoted to protected)",
+        cache.contains(&1)
+    );
+    println!(
+        "  contains 2? {} (was promoted to protected)",
+        cache.contains(&2)
+    );
+    println!("  len: {}", cache.len());
+
+    // Demonstrate scan resistance
+    println!("\n=== Scan Resistance Demo ===\n");
+
+    let mut cache = CacheBuilder::new(10).build::<u64, String>(CachePolicy::TwoQ {
+        probation_frac: 0.3, // 30% probation
+    });
+
+    // Insert "hot" items and access them to promote to protected queue
+    cache.insert(1, "hot-1".to_string());
+    cache.insert(2, "hot-2".to_string());
+    cache.insert(3, "hot-3".to_string());
+
+    // Multiple accesses promote items to protected queue
+    cache.get(&1);
+    cache.get(&2);
+    cache.get(&3);
+    println!("Inserted and promoted hot items: 1, 2, 3");
+
+    // Simulate a scan with one-time accesses (stay in probation, get evicted first)
+    println!("Simulating scan with items 100-120...");
+    for i in 100..=120 {
+        cache.insert(i, format!("scan-{}", i));
+    }
+
+    // Hot items should survive the scan because they're in protected queue
+    println!("\nAfter scan (21 one-time insertions):");
+    println!("  contains hot-1? {}", cache.contains(&1));
+    println!("  contains hot-2? {}", cache.contains(&2));
+    println!("  contains hot-3? {}", cache.contains(&3));
+    println!("  len: {}", cache.len());
+
+    // Show that scan items were evicted
+    let scan_items_remaining: Vec<_> = (100..=120).filter(|&i| cache.contains(&i)).collect();
+    println!("  scan items remaining: {:?}", scan_items_remaining);
+}
+
+// Expected output:
+// === 2Q Cache Example ===
+//
+// Created 2Q cache: capacity=10
+//
+// Inserted keys 1-5 (all in probation queue)
+//   len: 5
+//
+// Accessed keys 1 and 2 (promoted to protected queue)
+// Inserted keys 6-10
+//   len: 10
+//
+// After inserting keys 11, 12:
+//   contains 1? true (was promoted to protected)
+//   contains 2? true (was promoted to protected)
+//   len: 10
+//
+// === Scan Resistance Demo ===
+//
+// Inserted and promoted hot items: 1, 2, 3
+// Simulating scan with items 100-120...
+//
+// After scan (21 one-time insertions):
+//   contains hot-1? true
+//   contains hot-2? true
+//   contains hot-3? true
+//   len: 10
+//   scan items remaining: [last ~7 scan items]

--- a/src/ds/clock_ring.rs
+++ b/src/ds/clock_ring.rs
@@ -7,68 +7,157 @@
 //! ## Architecture
 //!
 //! ```text
-//!   ┌──────────────────────────────────────────────────────────────────────┐
-//!   │                         ClockRing<K, V>                               │
-//!   │                                                                       │
-//!   │   slots: Vec<Option<Entry<K,V>>>                                      │
-//!   │   hand ──────────────────────────────────────────────┐                │
-//!   │                                                      │                │
-//!   │   index: HashMap<K, usize> (key -> slot index)        │                │
-//!   │   ┌─────────┬─────────┐                               ▼                │
-//!   │   │  key A  │   0     │   slot[0] = Entry { ref:1 }  [A]               │
-//!   │   │  key B  │   1     │   slot[1] = Entry { ref:0 }  [B]               │
-//!   │   │  key C  │   2     │   slot[2] = Entry { ref:1 }  [C]               │
-//!   │   └─────────┴─────────┘   slot[3] = None              [ ]               │
-//!   │                                                                       │
-//!   │   Eviction scan (hand moves forward):                                 │
-//!   │   [A ref=1] -> clear ref, advance                                     │
-//!   │   [B ref=0] -> evict B, insert new entry here                         │
-//!   └──────────────────────────────────────────────────────────────────────┘
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                           ClockRing<K, V>                                   │
+//! │                                                                             │
+//! │   ┌─────────────────────────────┐   ┌─────────────────────────────────┐   │
+//! │   │  index: HashMap<K, usize>   │   │  slots: Vec<Option<Entry>>      │   │
+//! │   │                             │   │                                 │   │
+//! │   │  ┌───────────┬──────────┐  │   │  ┌─────┬─────┬─────┬─────┐     │   │
+//! │   │  │    Key    │  Index   │  │   │  │  0  │  1  │  2  │  3  │     │   │
+//! │   │  ├───────────┼──────────┤  │   │  ├─────┼─────┼─────┼─────┤     │   │
+//! │   │  │  "key_a"  │    0     │──┼───┼──►│ A,1 │ B,0 │ C,1 │None │     │   │
+//! │   │  │  "key_b"  │    1     │──┼───┼──►│     │     │     │     │     │   │
+//! │   │  │  "key_c"  │    2     │──┼───┼──►│     │     │     │     │     │   │
+//! │   │  └───────────┴──────────┘  │   │  └─────┴─────┴─────┴─────┘     │   │
+//! │   └─────────────────────────────┘   │                ▲               │   │
+//! │                                     │                │ hand = 1      │   │
+//! │                                     └────────────────┼───────────────┘   │
+//! │                                                      │                   │
+//! │   Entry: { key, value, referenced: bool }            │                   │
+//! │   "A,1" = Entry { key: "key_a", referenced: true }   │                   │
+//! │   "B,0" = Entry { key: "key_b", referenced: false } ◄┘ (next victim)     │
+//! │                                                                          │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!
+//! Clock Sweep Algorithm
+//! ─────────────────────
+//!
+//!   Insert "key_d" when full (hand at slot 1):
+//!
+//!     Step 1: Check slot[1] ("B", ref=0)
+//!             ref=0 → EVICT, insert here
+//!
+//!     Result: slot[1] = Entry { key: "key_d", ref=false }
+//!             hand advances to 2
+//!             Return: Some(("key_b", value_b))
+//!
+//!   Insert "key_e" when full (hand at slot 2):
+//!
+//!     Step 1: Check slot[2] ("C", ref=1)
+//!             ref=1 → clear ref, advance hand
+//!     Step 2: Check slot[3] (None)
+//!             Empty → insert here
+//!
+//!     Result: slot[3] = Entry { key: "key_e", ref=false }
+//!             hand advances to 0
+//!             Return: None (used empty slot)
+//!
+//! Second-Chance Behavior
+//! ──────────────────────
+//!
+//!   ┌────────────────────────────────────────────────────────────────────────┐
+//!   │  Access via get()/touch() → Sets referenced = true                    │
+//!   │                                                                        │
+//!   │  Eviction scan:                                                        │
+//!   │    ref=1 → Clear to ref=0, skip (second chance granted)               │
+//!   │    ref=0 → Evict this entry                                           │
+//!   │                                                                        │
+//!   │  Effect: Recently accessed entries survive longer                     │
+//!   └────────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
-//! ## Eviction Flow
+//! ## Key Components
 //!
-//! ```text
-//!   insert(key, value)
-//!        │
-//!        ▼
-//!   ┌──────────────────────────────────────────────────────────────────────┐
-//!   │ Key exists?                                                          │
-//!   │   YES → update value, set ref=1                                       │
-//!   │   NO  → scan from hand until ref=0 slot found                         │
-//!   └──────────────────────────────────────────────────────────────────────┘
-//!        │
-//!        ▼
-//!   ┌──────────────────────────────────────────────────────────────────────┐
-//!   │ At each slot:                                                        │
-//!   │   ref=1 → clear ref, advance hand                                    │
-//!   │   ref=0 → evict entry, replace slot, advance hand                    │
-//!   └──────────────────────────────────────────────────────────────────────┘
+//! - [`ClockRing`]: Single-threaded CLOCK cache
+//! - [`ConcurrentClockRing`]: Thread-safe wrapper with `RwLock`
+//!
+//! ## Operations
+//!
+//! | Operation     | Time        | Notes                                  |
+//! |---------------|-------------|----------------------------------------|
+//! | `insert`      | O(1) amort. | Bounded scan with reference clearing   |
+//! | `get`         | O(1)        | Returns value, sets reference bit      |
+//! | `peek`        | O(1)        | Returns value, does NOT set ref bit    |
+//! | `touch`       | O(1)        | Sets reference bit only                |
+//! | `remove`      | O(1)        | Clears slot + index entry              |
+//! | `pop_victim`  | O(1) amort. | Evicts next unreferenced entry         |
+//! | `peek_victim` | O(n) worst  | Finds next victim without modifying    |
+//!
+//! ## Use Cases
+//!
+//! - **Page replacement**: Classic use case for CLOCK algorithm
+//! - **Buffer pool**: Database buffer management
+//! - **Web cache**: Approximate LRU with lower overhead
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::ClockRing;
+//!
+//! let mut cache = ClockRing::new(3);
+//!
+//! // Insert entries
+//! cache.insert("page_1", "content_1");
+//! cache.insert("page_2", "content_2");
+//! cache.insert("page_3", "content_3");
+//!
+//! // Access sets the reference bit (second chance)
+//! cache.get(&"page_1");  // page_1 now has ref=1
+//!
+//! // Insert when full - evicts unreferenced entry
+//! let evicted = cache.insert("page_4", "content_4");
+//! // page_2 or page_3 evicted (page_1 protected by ref bit)
+//!
+//! assert!(cache.contains(&"page_1"));  // Survived due to reference bit
+//! assert!(cache.contains(&"page_4"));  // Newly inserted
 //! ```
 //!
-//! ## Entry Structure
+//! ## Use Case: Page Buffer
 //!
-//! ```text
-//!   Entry<K, V>
-//!   ┌───────────────────────────────┐
-//!   │ key: K                        │
-//!   │ value: V                      │
-//!   │ referenced: bool              │
-//!   └───────────────────────────────┘
+//! ```
+//! use cachekit::ds::ClockRing;
+//!
+//! struct PageBuffer {
+//!     cache: ClockRing<u64, Vec<u8>>,  // page_id -> page_data
+//! }
+//!
+//! impl PageBuffer {
+//!     fn new(capacity: usize) -> Self {
+//!         Self { cache: ClockRing::new(capacity) }
+//!     }
+//!
+//!     fn read_page(&mut self, page_id: u64) -> Option<&Vec<u8>> {
+//!         // get() sets reference bit, giving this page a second chance
+//!         self.cache.get(&page_id)
+//!     }
+//!
+//!     fn load_page(&mut self, page_id: u64, data: Vec<u8>) {
+//!         if let Some((evicted_id, _evicted_data)) = self.cache.insert(page_id, data) {
+//!             // Could write back dirty page here
+//!             println!("Evicted page {}", evicted_id);
+//!         }
+//!     }
+//! }
+//!
+//! let mut buffer = PageBuffer::new(100);
+//! buffer.load_page(1, vec![0; 4096]);
+//! buffer.load_page(2, vec![0; 4096]);
+//! assert!(buffer.read_page(1).is_some());
 //! ```
 //!
-//! ## Performance Characteristics
+//! ## Thread Safety
 //!
-//! | Operation  | Time        | Notes                                   |
-//! |-----------|-------------|-----------------------------------------|
-//! | `insert`  | O(1) amort. | Bounded scan with reference clearing     |
-//! | `get`     | O(1)        | Sets reference bit                       |
-//! | `touch`   | O(1)        | Sets reference bit                       |
-//! | `remove`  | O(1)        | Clears slot + index entry                |
+//! - [`ClockRing`]: Not thread-safe, use in single-threaded contexts
+//! - [`ConcurrentClockRing`]: Thread-safe via `parking_lot::RwLock`
 //!
-//! ## Notes
-//! - Slots are reused in place; keys map directly to slot indices.
-//! - `debug_validate_invariants()` is available in debug/test builds.
+//! ## Implementation Notes
+//!
+//! - Fixed-size slot array; no reallocation during operation
+//! - Keys mapped to slot indices via HashMap
+//! - Hand pointer advances after each insert/eviction
+//! - `debug_validate_invariants()` available in debug/test builds
+
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -81,8 +170,56 @@ struct Entry<K, V> {
     referenced: bool,
 }
 
-#[derive(Debug)]
 /// Fixed-size ring implementing the CLOCK (second-chance) eviction algorithm.
+///
+/// Provides O(1) amortized insertion with automatic eviction of unreferenced
+/// entries. Accessed entries receive a "second chance" via a reference bit.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Eq + Hash + Clone`
+/// - `V`: Value type
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::ClockRing;
+///
+/// let mut ring = ClockRing::new(2);
+///
+/// // Insert two entries
+/// ring.insert("a", 1);
+/// ring.insert("b", 2);
+///
+/// // Access "a" - sets reference bit
+/// ring.get(&"a");
+///
+/// // Insert "c" - "b" is evicted (no reference bit)
+/// let evicted = ring.insert("c", 3);
+/// assert_eq!(evicted, Some(("b", 2)));
+///
+/// assert!(ring.contains(&"a"));
+/// assert!(ring.contains(&"c"));
+/// ```
+///
+/// # Use Case: Simple Cache with Eviction Callback
+///
+/// ```
+/// use cachekit::ds::ClockRing;
+///
+/// let mut cache = ClockRing::new(3);
+/// let mut eviction_count = 0;
+///
+/// for i in 0..10 {
+///     if let Some((_key, _value)) = cache.insert(i, format!("value_{}", i)) {
+///         eviction_count += 1;
+///     }
+/// }
+///
+/// assert_eq!(cache.len(), 3);
+/// assert_eq!(eviction_count, 7);  // 10 inserts - 3 capacity = 7 evictions
+/// ```
+#[derive(Debug)]
 pub struct ClockRing<K, V> {
     slots: Vec<Option<Entry<K, V>>>,
     index: HashMap<K, usize>,
@@ -90,7 +227,54 @@ pub struct ClockRing<K, V> {
     len: usize,
 }
 
-/// Thread-safe wrapper around `ClockRing` using a `parking_lot::RwLock`.
+/// Thread-safe wrapper around [`ClockRing`] using `parking_lot::RwLock`.
+///
+/// Provides the same functionality as [`ClockRing`] but safe for concurrent
+/// access. Uses closure-based value access since references cannot outlive
+/// lock guards.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::ds::ConcurrentClockRing;
+///
+/// let cache = Arc::new(ConcurrentClockRing::new(100));
+///
+/// let handles: Vec<_> = (0..4).map(|t| {
+///     let cache = Arc::clone(&cache);
+///     thread::spawn(move || {
+///         for i in 0..25 {
+///             let key = t * 25 + i;
+///             cache.insert(key, key * 10);
+///         }
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert!(cache.len() <= 100);
+/// ```
+///
+/// # Non-blocking Operations
+///
+/// All operations have `try_*` variants that return `None` if the lock
+/// cannot be acquired immediately:
+///
+/// ```
+/// use cachekit::ds::ConcurrentClockRing;
+///
+/// let cache = ConcurrentClockRing::new(10);
+/// cache.insert("key", 42);
+///
+/// // Non-blocking read
+/// if let Some(Some(val)) = cache.try_get_with(&"key", |v| *v) {
+///     assert_eq!(val, 42);
+/// }
+/// ```
 #[derive(Debug)]
 pub struct ConcurrentClockRing<K, V> {
     inner: RwLock<ClockRing<K, V>>,
@@ -101,6 +285,16 @@ where
     K: Eq + Hash + Clone,
 {
     /// Creates a new ring with `capacity` slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache: ConcurrentClockRing<String, i32> = ConcurrentClockRing::new(100);
+    /// assert_eq!(cache.capacity(), 100);
+    /// assert!(cache.is_empty());
+    /// ```
     pub fn new(capacity: usize) -> Self {
         Self {
             inner: RwLock::new(ClockRing::new(capacity)),
@@ -108,114 +302,262 @@ where
     }
 
     /// Returns the configured capacity (number of slots).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache: ConcurrentClockRing<&str, i32> = ConcurrentClockRing::new(50);
+    /// assert_eq!(cache.capacity(), 50);
+    /// ```
     pub fn capacity(&self) -> usize {
         let ring = self.inner.read();
         ring.capacity()
     }
 
     /// Returns the number of occupied slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(10);
+    /// assert_eq!(cache.len(), 0);
+    ///
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    /// assert_eq!(cache.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         let ring = self.inner.read();
         ring.len()
     }
 
     /// Returns `true` if there are no entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache: ConcurrentClockRing<&str, i32> = ConcurrentClockRing::new(10);
+    /// assert!(cache.is_empty());
+    ///
+    /// cache.insert("key", 42);
+    /// assert!(!cache.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         let ring = self.inner.read();
         ring.is_empty()
     }
 
     /// Returns `true` if `key` is present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(10);
+    /// cache.insert("key", 42);
+    ///
+    /// assert!(cache.contains(&"key"));
+    /// assert!(!cache.contains(&"missing"));
+    /// ```
     pub fn contains(&self, key: &K) -> bool {
         let ring = self.inner.read();
         ring.contains(key)
     }
 
-    /// Returns a shared reference to `key`'s value without setting the reference bit.
+    /// Accesses value without setting the reference bit.
+    ///
+    /// Unlike [`get_with`](Self::get_with), this does not grant a second chance.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(10);
+    /// cache.insert("key", vec![1, 2, 3]);
+    ///
+    /// let sum = cache.peek_with(&"key", |v| v.iter().sum::<i32>());
+    /// assert_eq!(sum, Some(6));
+    /// ```
     pub fn peek_with<R>(&self, key: &K, f: impl FnOnce(&V) -> R) -> Option<R> {
         let ring = self.inner.read();
         ring.peek(key).map(f)
     }
 
-    /// Returns a shared reference to `key`'s value and sets the reference bit.
+    /// Accesses value and sets the reference bit (grants second chance).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(2);
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    ///
+    /// // Access "a" - sets reference bit
+    /// cache.get_with(&"a", |v| *v);
+    ///
+    /// // Insert "c" - "b" evicted (no ref bit), "a" survives
+    /// cache.insert("c", 3);
+    /// assert!(cache.contains(&"a"));
+    /// assert!(!cache.contains(&"b"));
+    /// ```
     pub fn get_with<R>(&self, key: &K, f: impl FnOnce(&V) -> R) -> Option<R> {
         let mut ring = self.inner.write();
         ring.get(key).map(f)
     }
 
     /// Sets the reference bit for `key`; returns `false` if missing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(10);
+    /// cache.insert("key", 42);
+    ///
+    /// assert!(cache.touch(&"key"));       // Sets reference bit
+    /// assert!(!cache.touch(&"missing"));  // Key not found
+    /// ```
     pub fn touch(&self, key: &K) -> bool {
         let mut ring = self.inner.write();
         ring.touch(key)
     }
 
-    /// Inserts or updates `key`.
+    /// Inserts or updates `key`, evicting if necessary.
+    ///
+    /// Returns `Some((evicted_key, evicted_value))` if an entry was evicted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(2);
+    /// assert_eq!(cache.insert("a", 1), None);  // No eviction
+    /// assert_eq!(cache.insert("b", 2), None);  // No eviction
+    ///
+    /// // Full - must evict
+    /// let evicted = cache.insert("c", 3);
+    /// assert!(evicted.is_some());
+    /// ```
     pub fn insert(&self, key: K, value: V) -> Option<(K, V)> {
         let mut ring = self.inner.write();
         ring.insert(key, value)
     }
 
     /// Removes `key` and returns its value, if present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(10);
+    /// cache.insert("key", 42);
+    ///
+    /// assert_eq!(cache.remove(&"key"), Some(42));
+    /// assert_eq!(cache.remove(&"key"), None);  // Already removed
+    /// ```
     pub fn remove(&self, key: &K) -> Option<V> {
         let mut ring = self.inner.write();
         ring.remove(key)
     }
 
     /// Peeks the next eviction candidate without modifying state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(2);
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    /// cache.touch(&"a");  // "a" now has ref bit
+    ///
+    /// // "b" is next victim (no ref bit)
+    /// let victim_key = cache.peek_victim_with(|k, _v| *k);
+    /// assert_eq!(victim_key, Some("b"));
+    /// ```
     pub fn peek_victim_with<R>(&self, f: impl FnOnce(&K, &V) -> R) -> Option<R> {
         let ring = self.inner.read();
         ring.peek_victim().map(|(key, value)| f(key, value))
     }
 
     /// Evicts the next candidate and returns it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentClockRing;
+    ///
+    /// let cache = ConcurrentClockRing::new(3);
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    /// cache.insert("c", 3);
+    ///
+    /// let evicted = cache.pop_victim();
+    /// assert!(evicted.is_some());
+    /// assert_eq!(cache.len(), 2);
+    /// ```
     pub fn pop_victim(&self) -> Option<(K, V)> {
         let mut ring = self.inner.write();
         ring.pop_victim()
     }
 
-    /// Tries to insert without blocking.
+    /// Non-blocking version of [`insert`](Self::insert).
     pub fn try_insert(&self, key: K, value: V) -> Option<Option<(K, V)>> {
         let mut ring = self.inner.try_write()?;
         Some(ring.insert(key, value))
     }
 
-    /// Tries to remove without blocking.
+    /// Non-blocking version of [`remove`](Self::remove).
     pub fn try_remove(&self, key: &K) -> Option<Option<V>> {
         let mut ring = self.inner.try_write()?;
         Some(ring.remove(key))
     }
 
-    /// Tries to touch without blocking.
+    /// Non-blocking version of [`touch`](Self::touch).
     pub fn try_touch(&self, key: &K) -> Option<bool> {
         let mut ring = self.inner.try_write()?;
         Some(ring.touch(key))
     }
 
-    /// Tries to peek without blocking.
+    /// Non-blocking version of [`peek_with`](Self::peek_with).
     pub fn try_peek_with<R>(&self, key: &K, f: impl FnOnce(&V) -> R) -> Option<Option<R>> {
         let ring = self.inner.try_read()?;
         Some(ring.peek(key).map(f))
     }
 
-    /// Tries to get without blocking.
+    /// Non-blocking version of [`get_with`](Self::get_with).
     pub fn try_get_with<R>(&self, key: &K, f: impl FnOnce(&V) -> R) -> Option<Option<R>> {
         let mut ring = self.inner.try_write()?;
         Some(ring.get(key).map(f))
     }
 
-    /// Tries to peek without blocking.
+    /// Non-blocking version of [`peek_victim_with`](Self::peek_victim_with).
     pub fn try_peek_victim_with<R>(&self, f: impl FnOnce(&K, &V) -> R) -> Option<Option<R>> {
         let ring = self.inner.try_read()?;
         Some(ring.peek_victim().map(|(key, value)| f(key, value)))
     }
 
-    /// Tries to pop a victim without blocking.
+    /// Non-blocking version of [`pop_victim`](Self::pop_victim).
     pub fn try_pop_victim(&self) -> Option<Option<(K, V)>> {
         let mut ring = self.inner.try_write()?;
         Some(ring.pop_victim())
     }
 
-    /// Tries to clear the ring without blocking.
+    /// Non-blocking clear. Returns `true` if successful.
     pub fn try_clear(&self) -> bool {
         if let Some(mut ring) = self.inner.try_write() {
             ring.clear();
@@ -225,7 +567,7 @@ where
         }
     }
 
-    /// Tries to clear and shrink without blocking.
+    /// Non-blocking clear and shrink. Returns `true` if successful.
     pub fn try_clear_shrink(&self) -> bool {
         if let Some(mut ring) = self.inner.try_write() {
             ring.clear_shrink();
@@ -240,6 +582,16 @@ where
     K: Eq + Hash + Clone,
 {
     /// Creates a new ring with `capacity` slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let ring: ClockRing<String, i32> = ClockRing::new(100);
+    /// assert_eq!(ring.capacity(), 100);
+    /// assert!(ring.is_empty());
+    /// ```
     pub fn new(capacity: usize) -> Self {
         let mut slots = Vec::with_capacity(capacity);
         slots.resize_with(capacity, || None);
@@ -252,22 +604,64 @@ where
     }
 
     /// Returns the configured capacity (number of slots).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let ring: ClockRing<&str, i32> = ClockRing::new(50);
+    /// assert_eq!(ring.capacity(), 50);
+    /// ```
     pub fn capacity(&self) -> usize {
         self.slots.len()
     }
 
     /// Reserves capacity for at least `additional` more index entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring: ClockRing<String, i32> = ClockRing::new(10);
+    /// ring.reserve_index(100);  // Pre-allocate index capacity
+    /// ```
     pub fn reserve_index(&mut self, additional: usize) {
         self.index.reserve(additional);
     }
 
     /// Shrinks internal storage to fit current contents.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring: ClockRing<&str, i32> = ClockRing::new(100);
+    /// ring.insert("a", 1);
+    /// ring.shrink_to_fit();
+    /// ```
     pub fn shrink_to_fit(&mut self) {
         self.index.shrink_to_fit();
         self.slots.shrink_to_fit();
     }
 
     /// Clears all entries without releasing capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(10);
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    ///
+    /// ring.clear();
+    /// assert!(ring.is_empty());
+    /// assert!(!ring.contains(&"a"));
+    /// ```
     pub fn clear(&mut self) {
         self.index.clear();
         for slot in &mut self.slots {
@@ -278,6 +672,18 @@ where
     }
 
     /// Clears all entries and shrinks internal storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(100);
+    /// ring.insert("a", 1);
+    ///
+    /// ring.clear_shrink();
+    /// assert!(ring.is_empty());
+    /// ```
     pub fn clear_shrink(&mut self) {
         self.clear();
         self.index.shrink_to_fit();
@@ -285,6 +691,16 @@ where
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let ring: ClockRing<u64, u64> = ClockRing::new(100);
+    /// let bytes = ring.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
             + self.index.capacity() * std::mem::size_of::<(K, usize)>()
@@ -292,27 +708,97 @@ where
     }
 
     /// Returns the number of occupied slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(10);
+    /// assert_eq!(ring.len(), 0);
+    ///
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    /// assert_eq!(ring.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns `true` if there are no entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring: ClockRing<&str, i32> = ClockRing::new(10);
+    /// assert!(ring.is_empty());
+    ///
+    /// ring.insert("key", 42);
+    /// assert!(!ring.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Returns `true` if `key` is present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(10);
+    /// ring.insert("key", 42);
+    ///
+    /// assert!(ring.contains(&"key"));
+    /// assert!(!ring.contains(&"missing"));
+    /// ```
     pub fn contains(&self, key: &K) -> bool {
         self.index.contains_key(key)
     }
 
-    /// Returns a shared reference to `key`'s value without setting the reference bit.
+    /// Returns the value without setting the reference bit.
+    ///
+    /// Unlike [`get`](Self::get), this does not grant a second chance.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(10);
+    /// ring.insert("key", 42);
+    ///
+    /// // peek doesn't set reference bit
+    /// assert_eq!(ring.peek(&"key"), Some(&42));
+    /// assert_eq!(ring.peek(&"missing"), None);
+    /// ```
     pub fn peek(&self, key: &K) -> Option<&V> {
         let idx = *self.index.get(key)?;
         self.slots.get(idx)?.as_ref().map(|entry| &entry.value)
     }
 
-    /// Returns a shared reference to `key`'s value and sets the reference bit.
+    /// Returns the value and sets the reference bit (grants second chance).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(2);
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    ///
+    /// // Access "a" - sets reference bit
+    /// assert_eq!(ring.get(&"a"), Some(&1));
+    ///
+    /// // Insert "c" - "b" evicted (no ref bit), "a" survives
+    /// ring.insert("c", 3);
+    /// assert!(ring.contains(&"a"));
+    /// assert!(!ring.contains(&"b"));
+    /// ```
     pub fn get(&mut self, key: &K) -> Option<&V> {
         let idx = *self.index.get(key)?;
         let entry = self.slots.get_mut(idx)?.as_mut()?;
@@ -321,6 +807,26 @@ where
     }
 
     /// Sets the reference bit for `key`; returns `false` if missing.
+    ///
+    /// Use this to mark an entry as recently accessed without retrieving its value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(2);
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    ///
+    /// // Touch "a" without reading value
+    /// assert!(ring.touch(&"a"));
+    /// assert!(!ring.touch(&"missing"));
+    ///
+    /// // "a" survives eviction due to reference bit
+    /// let evicted = ring.insert("c", 3);
+    /// assert_eq!(evicted, Some(("b", 2)));
+    /// ```
     pub fn touch(&mut self, key: &K) -> bool {
         let idx = match self.index.get(key) {
             Some(idx) => *idx,
@@ -333,9 +839,30 @@ where
         false
     }
 
-    /// Inserts or updates `key`.
+    /// Inserts or updates `key`, evicting if necessary.
     ///
     /// If inserting into a full ring, evicts and returns `(evicted_key, evicted_value)`.
+    /// Updating an existing key sets its reference bit but does not evict.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(2);
+    ///
+    /// // Insert into empty slots - no eviction
+    /// assert_eq!(ring.insert("a", 1), None);
+    /// assert_eq!(ring.insert("b", 2), None);
+    ///
+    /// // Update existing - no eviction
+    /// assert_eq!(ring.insert("a", 10), None);
+    /// assert_eq!(ring.peek(&"a"), Some(&10));
+    ///
+    /// // Insert new when full - evicts unreferenced entry
+    /// let evicted = ring.insert("c", 3);
+    /// assert!(evicted.is_some());
+    /// ```
     pub fn insert(&mut self, key: K, value: V) -> Option<(K, V)> {
         if self.capacity() == 0 {
             return None;
@@ -386,6 +913,23 @@ where
     }
 
     /// Peeks the next eviction candidate without modifying state.
+    ///
+    /// Scans from the hand position to find the first unreferenced entry.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(2);
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    /// ring.touch(&"a");  // "a" now has reference bit
+    ///
+    /// // "b" is the next victim (no reference bit)
+    /// let victim = ring.peek_victim();
+    /// assert_eq!(victim, Some((&"b", &2)));
+    /// ```
     pub fn peek_victim(&self) -> Option<(&K, &V)> {
         if self.capacity() == 0 || self.len == 0 {
             return None;
@@ -403,6 +947,24 @@ where
     }
 
     /// Evicts the next candidate (first unreferenced slot) and returns it.
+    ///
+    /// Clears reference bits as it scans, giving referenced entries a second chance.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(3);
+    /// ring.insert("a", 1);
+    /// ring.insert("b", 2);
+    /// ring.insert("c", 3);
+    ///
+    /// // Evict one entry
+    /// let evicted = ring.pop_victim();
+    /// assert!(evicted.is_some());
+    /// assert_eq!(ring.len(), 2);
+    /// ```
     pub fn pop_victim(&mut self) -> Option<(K, V)> {
         if self.capacity() == 0 || self.len == 0 {
             return None;
@@ -438,6 +1000,19 @@ where
     }
 
     /// Removes `key` and returns its value, if present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ClockRing;
+    ///
+    /// let mut ring = ClockRing::new(10);
+    /// ring.insert("key", 42);
+    ///
+    /// assert_eq!(ring.remove(&"key"), Some(42));
+    /// assert_eq!(ring.remove(&"key"), None);  // Already removed
+    /// assert!(!ring.contains(&"key"));
+    /// ```
     pub fn remove(&mut self, key: &K) -> Option<V> {
         let idx = self.index.remove(key)?;
         let entry = self.slots.get_mut(idx)?.take()?;

--- a/src/ds/fixed_history.rs
+++ b/src/ds/fixed_history.rs
@@ -1,34 +1,201 @@
-//! Fixed-size access history ring.
+//! Fixed-size access history ring buffer.
 //!
 //! Stores the last `K` timestamps in a ring buffer, providing O(1) record
-//! and O(1) access to the k-th most recent entry.
+//! and O(1) access to the k-th most recent entry. Essential for LRU-K policies
+//! where eviction decisions depend on the K-th most recent access time.
 //!
 //! ## Architecture
 //!
 //! ```text
-//!   data: [u64; K]     cursor: write index
-//!   len: number of valid entries (<= K)
-//!
-//!   data  = [10, 20, 30]
-//!   cursor = 0   (next write overwrites oldest)
-//!
-//!   most_recent (k=1) => data[(cursor + K - 1) % K]
-//!   kth_most_recent(k) => data[(cursor + K - k) % K]
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                      FixedHistory<K=4> Layout                               │
+//! │                                                                             │
+//! │   Ring Buffer                                                               │
+//! │   ────────────                                                              │
+//! │                                                                             │
+//! │   data: [u64; K]              cursor: next write position                   │
+//! │   len: valid entries          (wraps around when full)                      │
+//! │                                                                             │
+//! │   After recording: 10, 20, 30, 40, 50                                       │
+//! │                                                                             │
+//! │   Index:     0     1     2     3                                            │
+//! │            ┌─────┬─────┬─────┬─────┐                                        │
+//! │   data:    │ 50  │ 20  │ 30  │ 40  │                                        │
+//! │            └─────┴─────┴─────┴─────┘                                        │
+//! │              ▲                                                              │
+//! │              │                                                              │
+//! │           cursor = 1 (next write goes here)                                 │
+//! │                                                                             │
+//! │   Access Pattern                                                            │
+//! │   ──────────────                                                            │
+//! │                                                                             │
+//! │   kth_most_recent(k) = data[(cursor + K - k) % K]                           │
+//! │                                                                             │
+//! │   k=1 (most recent):  data[(1 + 4 - 1) % 4] = data[0] = 50                  │
+//! │   k=2:                data[(1 + 4 - 2) % 4] = data[3] = 40                  │
+//! │   k=3:                data[(1 + 4 - 3) % 4] = data[2] = 30                  │
+//! │   k=4 (oldest):       data[(1 + 4 - 4) % 4] = data[1] = 20                  │
+//! │                                                                             │
+//! │   Record Flow                                                               │
+//! │   ───────────                                                               │
+//! │                                                                             │
+//! │   record(60):                                                               │
+//! │     1. data[cursor] = 60         → data[1] = 60                             │
+//! │     2. cursor = (cursor + 1) % K → cursor = 2                               │
+//! │     3. len stays at K (already full)                                        │
+//! │                                                                             │
+//! └─────────────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
-//! ## Behavior
-//! - `record(ts)`: writes at cursor, overwriting oldest when full
-//! - `most_recent` / `kth_most_recent`: read from ring
-//! - `to_vec_mru`: returns values from most-recent → least-recent
+//! ## Key Components
 //!
-//! ## Performance
-//! - `record`: O(1)
-//! - `kth_most_recent`: O(1)
-//! - `to_vec_mru`: O(K)
+//! - [`FixedHistory`]: Fixed-size ring buffer for timestamp history
 //!
-//! `debug_validate_invariants()` is available in debug/test builds.
-#[derive(Debug, Clone)]
+//! ## Operations
+//!
+//! | Operation         | Description                      | Complexity |
+//! |-------------------|----------------------------------|------------|
+//! | `record`          | Add timestamp (overwrites oldest)| O(1)       |
+//! | `most_recent`     | Get most recent timestamp        | O(1)       |
+//! | `kth_most_recent` | Get k-th most recent timestamp   | O(1)       |
+//! | `to_vec_mru`      | Get all in MRU order             | O(K)       |
+//!
+//! ## Use Cases
+//!
+//! - **LRU-K policy**: Track last K access times per entry for eviction decisions
+//! - **Access frequency**: Count accesses within a time window
+//! - **Temporal patterns**: Detect periodic access patterns
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::FixedHistory;
+//!
+//! // Track last 3 access times
+//! let mut history = FixedHistory::<3>::new();
+//!
+//! // Record access timestamps
+//! history.record(100);
+//! history.record(200);
+//! history.record(300);
+//!
+//! // Most recent access
+//! assert_eq!(history.most_recent(), Some(300));
+//!
+//! // LRU-K: Get K-th most recent for eviction comparison
+//! assert_eq!(history.kth_most_recent(3), Some(100));  // Oldest of K
+//!
+//! // Overwrites oldest when full
+//! history.record(400);
+//! assert_eq!(history.to_vec_mru(), vec![400, 300, 200]);  // 100 is gone
+//! ```
+//!
+//! ## Use Case: LRU-2 Eviction
+//!
+//! ```
+//! use cachekit::ds::FixedHistory;
+//!
+//! // LRU-2: Evict based on 2nd most recent access time
+//! struct CacheEntry {
+//!     value: String,
+//!     history: FixedHistory<2>,
+//! }
+//!
+//! impl CacheEntry {
+//!     fn new(value: String, timestamp: u64) -> Self {
+//!         let mut entry = CacheEntry {
+//!             value,
+//!             history: FixedHistory::new(),
+//!         };
+//!         entry.history.record(timestamp);
+//!         entry
+//!     }
+//!
+//!     fn access(&mut self, timestamp: u64) {
+//!         self.history.record(timestamp);
+//!     }
+//!
+//!     // LRU-2 uses the 2nd most recent access for comparison
+//!     fn eviction_priority(&self) -> u64 {
+//!         // If only 1 access, use that; otherwise use 2nd most recent
+//!         self.history.kth_most_recent(2)
+//!             .or(self.history.most_recent())
+//!             .unwrap_or(0)
+//!     }
+//! }
+//!
+//! let mut entry = CacheEntry::new("data".into(), 100);
+//! assert_eq!(entry.eviction_priority(), 100);  // Only 1 access
+//!
+//! entry.access(200);
+//! assert_eq!(entry.eviction_priority(), 100);  // 2nd most recent = 100
+//!
+//! entry.access(300);
+//! assert_eq!(entry.eviction_priority(), 200);  // 2nd most recent = 200
+//! ```
+//!
+//! ## Thread Safety
+//!
+//! `FixedHistory` is not thread-safe. It is typically embedded within
+//! cache entries and protected by the cache's synchronization.
+//!
+//! ## Implementation Notes
+//!
+//! - Uses a fixed-size array (no heap allocation)
+//! - Const generic `K` determines history depth at compile time
+//! - Zero-size history (`K=0`) is a no-op
+//! - `debug_validate_invariants()` available in debug/test builds
+
 /// Fixed-size ring buffer of the last `K` timestamps.
+///
+/// Stores timestamps in a circular buffer, automatically overwriting the oldest
+/// entry when full. Provides O(1) access to any of the last K timestamps.
+///
+/// # Type Parameters
+///
+/// - `K`: Maximum number of timestamps to retain (const generic)
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::FixedHistory;
+///
+/// let mut history = FixedHistory::<3>::new();
+///
+/// history.record(10);
+/// history.record(20);
+/// history.record(30);
+///
+/// assert_eq!(history.most_recent(), Some(30));
+/// assert_eq!(history.kth_most_recent(2), Some(20));
+/// assert_eq!(history.kth_most_recent(3), Some(10));
+///
+/// // When full, oldest is overwritten
+/// history.record(40);
+/// assert_eq!(history.to_vec_mru(), vec![40, 30, 20]);
+/// ```
+///
+/// # Use Case: Access Frequency Window
+///
+/// ```
+/// use cachekit::ds::FixedHistory;
+///
+/// // Track last 5 access times
+/// let mut history = FixedHistory::<5>::new();
+///
+/// // Simulate accesses at various times
+/// for ts in [100, 150, 180, 200, 250] {
+///     history.record(ts);
+/// }
+///
+/// // Check if accessed recently (within last 100 time units)
+/// let now = 260;
+/// let oldest_in_window = history.kth_most_recent(5).unwrap();
+/// let window_duration = now - oldest_in_window;
+///
+/// assert_eq!(window_duration, 160);  // 5 accesses over 160 time units
+/// ```
+#[derive(Debug, Clone)]
 pub struct FixedHistory<const K: usize> {
     data: [u64; K],
     len: usize,
@@ -37,6 +204,16 @@ pub struct FixedHistory<const K: usize> {
 
 impl<const K: usize> FixedHistory<K> {
     /// Creates an empty history.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let history = FixedHistory::<4>::new();
+    /// assert!(history.is_empty());
+    /// assert_eq!(history.capacity(), 4);
+    /// ```
     pub fn new() -> Self {
         Self {
             data: [0; K],
@@ -46,21 +223,76 @@ impl<const K: usize> FixedHistory<K> {
     }
 
     /// Returns the maximum number of timestamps retained.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let history = FixedHistory::<5>::new();
+    /// assert_eq!(history.capacity(), 5);
+    /// ```
     pub fn capacity(&self) -> usize {
         K
     }
 
     /// Returns the number of timestamps currently stored (<= `K`).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// assert_eq!(history.len(), 0);
+    ///
+    /// history.record(100);
+    /// history.record(200);
+    /// assert_eq!(history.len(), 2);
+    ///
+    /// // Length caps at K
+    /// history.record(300);
+    /// history.record(400);
+    /// assert_eq!(history.len(), 3);  // Still 3, oldest was overwritten
+    /// ```
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns `true` if there are no timestamps recorded.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// assert!(history.is_empty());
+    ///
+    /// history.record(100);
+    /// assert!(!history.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Records a timestamp, overwriting the oldest if the history is full.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<2>::new();
+    ///
+    /// history.record(10);
+    /// history.record(20);
+    /// assert_eq!(history.to_vec_mru(), vec![20, 10]);
+    ///
+    /// // Overwrites oldest (10)
+    /// history.record(30);
+    /// assert_eq!(history.to_vec_mru(), vec![30, 20]);
+    /// ```
     pub fn record(&mut self, timestamp: u64) {
         if K == 0 {
             return;
@@ -73,11 +305,49 @@ impl<const K: usize> FixedHistory<K> {
     }
 
     /// Returns the most recently recorded timestamp.
+    ///
+    /// Returns `None` if the history is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// assert_eq!(history.most_recent(), None);
+    ///
+    /// history.record(100);
+    /// history.record(200);
+    /// assert_eq!(history.most_recent(), Some(200));
+    /// ```
     pub fn most_recent(&self) -> Option<u64> {
         self.kth_most_recent(1)
     }
 
     /// Returns the k-th most recent timestamp (`k = 1` is most recent).
+    ///
+    /// Returns `None` if `k` is 0, exceeds the number of recorded timestamps,
+    /// or if the history is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<4>::new();
+    /// history.record(10);
+    /// history.record(20);
+    /// history.record(30);
+    ///
+    /// // k=1 is most recent, k=3 is oldest
+    /// assert_eq!(history.kth_most_recent(1), Some(30));
+    /// assert_eq!(history.kth_most_recent(2), Some(20));
+    /// assert_eq!(history.kth_most_recent(3), Some(10));
+    ///
+    /// // Out of bounds
+    /// assert_eq!(history.kth_most_recent(0), None);
+    /// assert_eq!(history.kth_most_recent(4), None);  // Only 3 recorded
+    /// ```
     pub fn kth_most_recent(&self, k: usize) -> Option<u64> {
         if K == 0 || k == 0 || k > self.len {
             return None;
@@ -87,6 +357,23 @@ impl<const K: usize> FixedHistory<K> {
     }
 
     /// Returns timestamps from most-recent to least-recent.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// history.record(100);
+    /// history.record(200);
+    /// history.record(300);
+    ///
+    /// assert_eq!(history.to_vec_mru(), vec![300, 200, 100]);
+    ///
+    /// // After wrap
+    /// history.record(400);
+    /// assert_eq!(history.to_vec_mru(), vec![400, 300, 200]);
+    /// ```
     pub fn to_vec_mru(&self) -> Vec<u64> {
         (1..=self.len)
             .filter_map(|k| self.kth_most_recent(k))
@@ -94,17 +381,61 @@ impl<const K: usize> FixedHistory<K> {
     }
 
     /// Clears the history and resets cursor/length.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// history.record(10);
+    /// history.record(20);
+    ///
+    /// history.clear();
+    /// assert!(history.is_empty());
+    /// assert_eq!(history.most_recent(), None);
+    /// ```
     pub fn clear(&mut self) {
         self.len = 0;
         self.cursor = 0;
     }
 
     /// Clears the history (no heap allocations to shrink).
+    ///
+    /// Equivalent to [`clear`](Self::clear) since `FixedHistory` uses
+    /// a fixed-size array with no heap allocation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let mut history = FixedHistory::<3>::new();
+    /// history.record(10);
+    ///
+    /// history.clear_shrink();
+    /// assert!(history.is_empty());
+    /// ```
     pub fn clear_shrink(&mut self) {
         self.clear();
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// Since `FixedHistory` uses a fixed-size array, this is constant
+    /// regardless of how many timestamps are recorded.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::FixedHistory;
+    ///
+    /// let history = FixedHistory::<10>::new();
+    /// let bytes = history.approx_bytes();
+    ///
+    /// // Includes array of 10 u64s plus len and cursor
+    /// assert!(bytes >= 10 * std::mem::size_of::<u64>());
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
     }

--- a/src/ds/ghost_list.rs
+++ b/src/ds/ghost_list.rs
@@ -1,7 +1,7 @@
 //! Bounded recency list for ghost entries.
 //!
 //! Used by adaptive policies (ARC/2Q-style) to track recently evicted keys
-//! without storing values. Implemented as an [`IntrusiveList`](crate::ds::IntrusiveList)
+//! without storing values. Implemented as an [`IntrusiveList`]
 //! plus a [`HashMap`] index for O(1) lookups.
 //!
 //! ## Architecture
@@ -130,7 +130,7 @@
 //!
 //! ## Implementation Notes
 //!
-//! - Backed by [`IntrusiveList`](crate::ds::IntrusiveList) for O(1) reordering
+//! - Backed by [`IntrusiveList`] for O(1) reordering
 //! - Keys are stored in both the list and index (requires `Clone`)
 //! - Zero-capacity ghost lists are no-ops (record does nothing)
 //! - `debug_validate_invariants()` available in debug/test builds

--- a/src/ds/interner.rs
+++ b/src/ds/interner.rs
@@ -1,12 +1,171 @@
 //! Simple key interner for mapping external keys to compact handles.
 //!
-//! This is useful with `LFUHandleCache` (or other handle-based structures)
-//! to avoid cloning large keys in hot paths.
+//! Assigns monotonically increasing `u64` handles to unique keys, enabling
+//! fast lookups while avoiding repeated key cloning in hot paths.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                         KeyInterner Layout                                  │
+//! │                                                                             │
+//! │   ┌─────────────────────────────────────────────────────────────────────┐  │
+//! │   │  index: HashMap<K, u64>              keys: Vec<K>                   │  │
+//! │   │                                                                     │  │
+//! │   │  ┌────────────────────────┐          ┌─────────────────────────┐   │  │
+//! │   │  │  Key         Handle    │          │ Index   Key             │   │  │
+//! │   │  ├────────────────────────┤          ├─────────────────────────┤   │  │
+//! │   │  │  "user:123"  → 0       │          │   0     "user:123"      │   │  │
+//! │   │  │  "user:456"  → 1       │          │   1     "user:456"      │   │  │
+//! │   │  │  "session:a" → 2       │          │   2     "session:a"     │   │  │
+//! │   │  └────────────────────────┘          └─────────────────────────┘   │  │
+//! │   │                                                                     │  │
+//! │   │  intern("user:123") ──► lookup in index ──► return 0               │  │
+//! │   │  resolve(1) ──► keys[1] ──► "user:456"                             │  │
+//! │   └─────────────────────────────────────────────────────────────────────┘  │
+//! │                                                                             │
+//! │   Data Flow                                                                │
+//! │   ─────────                                                                │
+//! │     intern(key):                                                           │
+//! │       1. Check index for existing handle                                   │
+//! │       2. If found: return handle                                           │
+//! │       3. If not: assign handle = keys.len(), store in both structures      │
+//! │                                                                             │
+//! │     resolve(handle):                                                       │
+//! │       1. Direct index into keys vector: O(1)                               │
+//! │                                                                             │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Key Components
+//!
+//! - [`KeyInterner`]: Maps keys to compact `u64` handles
+//!
+//! ## Operations
+//!
+//! | Operation    | Description                          | Complexity |
+//! |--------------|--------------------------------------|------------|
+//! | `intern`     | Get or create handle for key         | O(1) avg   |
+//! | `get_handle` | Lookup handle without inserting      | O(1) avg   |
+//! | `resolve`    | Convert handle back to key reference | O(1)       |
+//!
+//! ## Use Cases
+//!
+//! - **Handle-based caches**: Avoid cloning large keys on every access
+//! - **Frequency tracking**: Use compact handles as frequency map keys
+//! - **Deduplication**: Ensure each unique key has exactly one handle
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::KeyInterner;
+//!
+//! let mut interner = KeyInterner::new();
+//!
+//! // Intern keys to get compact handles
+//! let h1 = interner.intern(&"long_key_name_1".to_string());
+//! let h2 = interner.intern(&"long_key_name_2".to_string());
+//!
+//! // Same key returns same handle
+//! let h1_again = interner.intern(&"long_key_name_1".to_string());
+//! assert_eq!(h1, h1_again);
+//!
+//! // Resolve handle back to key
+//! assert_eq!(interner.resolve(h1), Some(&"long_key_name_1".to_string()));
+//! ```
+//!
+//! ## Use Case: Handle-Based Cache
+//!
+//! ```
+//! use cachekit::ds::KeyInterner;
+//! use std::collections::HashMap;
+//!
+//! // External keys are strings, internal cache uses u64 handles
+//! let mut interner = KeyInterner::new();
+//! let mut cache: HashMap<u64, Vec<u8>> = HashMap::new();
+//!
+//! fn put(interner: &mut KeyInterner<String>, cache: &mut HashMap<u64, Vec<u8>>,
+//!        key: &str, value: Vec<u8>) {
+//!     let handle = interner.intern(&key.to_string());
+//!     cache.insert(handle, value);
+//! }
+//!
+//! fn get<'a>(interner: &KeyInterner<String>, cache: &'a HashMap<u64, Vec<u8>>,
+//!            key: &str) -> Option<&'a Vec<u8>> {
+//!     let handle = interner.get_handle(&key.to_string())?;
+//!     cache.get(&handle)
+//! }
+//!
+//! put(&mut interner, &mut cache, "session:abc", vec![1, 2, 3]);
+//! assert!(get(&interner, &cache, "session:abc").is_some());
+//! ```
+//!
+//! ## Thread Safety
+//!
+//! `KeyInterner` is not thread-safe. For concurrent use, wrap in
+//! `parking_lot::RwLock` or similar synchronization primitive.
+//!
+//! ## Implementation Notes
+//!
+//! - Handles are assigned monotonically starting at 0
+//! - Keys are never removed (append-only design)
+//! - Both `index` and `keys` store copies of the key
 
 use std::collections::HashMap;
 use std::hash::Hash;
 
 /// Monotonic key interner that assigns a `u64` handle to each unique key.
+///
+/// Maps external keys to compact `u64` handles for efficient storage and lookup.
+/// Handles are assigned sequentially starting from 0 and never reused.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Eq + Hash + Clone`
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::KeyInterner;
+///
+/// let mut interner = KeyInterner::new();
+///
+/// // Intern returns a handle
+/// let handle = interner.intern(&"my_key");
+/// assert_eq!(handle, 0);  // First key gets handle 0
+///
+/// // Same key returns same handle
+/// assert_eq!(interner.intern(&"my_key"), 0);
+///
+/// // Different key gets next handle
+/// assert_eq!(interner.intern(&"other_key"), 1);
+///
+/// // Resolve handle back to key
+/// assert_eq!(interner.resolve(0), Some(&"my_key"));
+/// ```
+///
+/// # Use Case: Frequency Tracking
+///
+/// ```
+/// use cachekit::ds::KeyInterner;
+/// use std::collections::HashMap;
+///
+/// let mut interner = KeyInterner::new();
+/// let mut freq: HashMap<u64, u32> = HashMap::new();
+///
+/// // Track access frequency using handles (cheaper than cloning keys)
+/// fn access(interner: &mut KeyInterner<String>, freq: &mut HashMap<u64, u32>, key: &str) {
+///     let handle = interner.intern(&key.to_string());
+///     *freq.entry(handle).or_insert(0) += 1;
+/// }
+///
+/// access(&mut interner, &mut freq, "page_a");
+/// access(&mut interner, &mut freq, "page_a");
+/// access(&mut interner, &mut freq, "page_b");
+///
+/// let handle_a = interner.get_handle(&"page_a".to_string()).unwrap();
+/// assert_eq!(freq[&handle_a], 2);
+/// ```
 #[derive(Debug, Default)]
 pub struct KeyInterner<K> {
     index: HashMap<K, u64>,
@@ -18,6 +177,15 @@ where
     K: Eq + Hash + Clone,
 {
     /// Creates an empty interner.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let interner: KeyInterner<String> = KeyInterner::new();
+    /// assert!(interner.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             index: HashMap::new(),
@@ -26,6 +194,30 @@ where
     }
 
     /// Returns the handle for `key`, inserting it if missing.
+    ///
+    /// If the key is already interned, returns the existing handle.
+    /// Otherwise, assigns the next sequential handle and stores the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner = KeyInterner::new();
+    ///
+    /// // First key gets handle 0
+    /// let h1 = interner.intern(&"key_a");
+    /// assert_eq!(h1, 0);
+    ///
+    /// // Second key gets handle 1
+    /// let h2 = interner.intern(&"key_b");
+    /// assert_eq!(h2, 1);
+    ///
+    /// // Same key returns same handle (no new entry)
+    /// let h1_again = interner.intern(&"key_a");
+    /// assert_eq!(h1_again, 0);
+    /// assert_eq!(interner.len(), 2);  // Still only 2 keys
+    /// ```
     pub fn intern(&mut self, key: &K) -> u64 {
         if let Some(&id) = self.index.get(key) {
             return id;
@@ -37,26 +229,99 @@ where
     }
 
     /// Returns the handle for `key` if it exists.
+    ///
+    /// Does not insert the key if missing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner = KeyInterner::new();
+    /// let handle = interner.intern(&"existing");
+    ///
+    /// assert_eq!(interner.get_handle(&"existing"), Some(handle));
+    /// assert_eq!(interner.get_handle(&"missing"), None);
+    /// ```
     pub fn get_handle(&self, key: &K) -> Option<u64> {
         self.index.get(key).copied()
     }
 
     /// Resolves a handle to its original key.
+    ///
+    /// Returns `None` if the handle is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner = KeyInterner::new();
+    /// let handle = interner.intern(&"my_key");
+    ///
+    /// assert_eq!(interner.resolve(handle), Some(&"my_key"));
+    /// assert_eq!(interner.resolve(999), None);  // Invalid handle
+    /// ```
     pub fn resolve(&self, handle: u64) -> Option<&K> {
         self.keys.get(handle as usize)
     }
 
     /// Returns the number of interned keys.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner = KeyInterner::new();
+    /// assert_eq!(interner.len(), 0);
+    ///
+    /// interner.intern(&"a");
+    /// interner.intern(&"b");
+    /// assert_eq!(interner.len(), 2);
+    ///
+    /// // Re-interning same key doesn't increase count
+    /// interner.intern(&"a");
+    /// assert_eq!(interner.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.keys.len()
     }
 
     /// Returns `true` if no keys are interned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner: KeyInterner<&str> = KeyInterner::new();
+    /// assert!(interner.is_empty());
+    ///
+    /// interner.intern(&"key");
+    /// assert!(!interner.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
     }
 
     /// Clears all interned keys and shrinks internal storage.
+    ///
+    /// After calling this, all previously returned handles become invalid.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner = KeyInterner::new();
+    /// let handle = interner.intern(&"key");
+    /// assert_eq!(interner.resolve(handle), Some(&"key"));
+    ///
+    /// interner.clear_shrink();
+    /// assert!(interner.is_empty());
+    /// assert_eq!(interner.resolve(handle), None);  // Handle now invalid
+    /// ```
     pub fn clear_shrink(&mut self) {
         self.index.clear();
         self.keys.clear();
@@ -65,6 +330,22 @@ where
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::KeyInterner;
+    ///
+    /// let mut interner: KeyInterner<String> = KeyInterner::new();
+    /// let base_bytes = interner.approx_bytes();
+    ///
+    /// // Add some keys
+    /// for i in 0..100 {
+    ///     interner.intern(&format!("key_{}", i));
+    /// }
+    ///
+    /// assert!(interner.approx_bytes() > base_bytes);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
             + self.index.capacity() * std::mem::size_of::<(K, u64)>()

--- a/src/ds/intrusive_list.rs
+++ b/src/ds/intrusive_list.rs
@@ -1,7 +1,7 @@
-//! Intrusive doubly linked list backed by [`SlotArena`](crate::ds::SlotArena).
+//! Intrusive doubly linked list backed by [`SlotArena`].
 //!
-//! Stores list nodes in a [`SlotArena`](crate::ds::SlotArena) and links them via
-//! [`SlotId`](crate::ds::SlotId), enabling stable handles and O(1) splice/move
+//! Stores list nodes in a [`SlotArena`] and links them via
+//! [`SlotId`], enabling stable handles and O(1) splice/move
 //! operations. Ideal for LRU ordering, eviction queues, and policy metadata.
 //!
 //! ## Architecture
@@ -62,7 +62,7 @@
 //!
 //! - [`IntrusiveList`]: Single-threaded doubly linked list
 //! - [`ConcurrentIntrusiveList`]: Thread-safe wrapper with `RwLock`
-//! - [`SlotId`](crate::ds::SlotId): Stable handle for O(1) node access
+//! - [`SlotId`]: Stable handle for O(1) node access
 //!
 //! ## Operations
 //!
@@ -130,7 +130,7 @@
 //!
 //! ## Implementation Notes
 //!
-//! - Backed by [`SlotArena`](crate::ds::SlotArena) for stable handles
+//! - Backed by [`SlotArena`] for stable handles
 //! - No pointer chasing; links are `SlotId` indices
 //! - `debug_validate_invariants()` available in debug/test builds
 use parking_lot::RwLock;
@@ -145,10 +145,10 @@ struct Node<T> {
     epoch: u64,
 }
 
-/// Doubly linked list backed by [`SlotArena`](crate::ds::SlotArena).
+/// Doubly linked list backed by [`SlotArena`].
 ///
 /// Provides O(1) insertion, removal, and reordering operations. Each node
-/// is identified by a stable [`SlotId`](crate::ds::SlotId) that remains valid
+/// is identified by a stable [`SlotId`] that remains valid
 /// until the node is removed.
 ///
 /// # Example
@@ -312,7 +312,7 @@ impl<T> IntrusiveList<T> {
             .and_then(|id| self.arena.get(id).map(|node| &node.value))
     }
 
-    /// Returns the [`SlotId`](crate::ds::SlotId) at the front.
+    /// Returns the [`SlotId`] at the front.
     ///
     /// # Example
     ///
@@ -344,7 +344,7 @@ impl<T> IntrusiveList<T> {
             .and_then(|id| self.arena.get(id).map(|node| &node.value))
     }
 
-    /// Returns the [`SlotId`](crate::ds::SlotId) at the back.
+    /// Returns the [`SlotId`] at the back.
     ///
     /// # Example
     ///
@@ -382,7 +382,7 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Returns an iterator of [`SlotId`](crate::ds::SlotId)s from front to back.
+    /// Returns an iterator of [`SlotId`]s from front to back.
     ///
     /// # Example
     ///
@@ -425,7 +425,7 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Returns the value for a node by its [`SlotId`](crate::ds::SlotId).
+    /// Returns the value for a node by its [`SlotId`].
     ///
     /// # Example
     ///
@@ -460,7 +460,7 @@ impl<T> IntrusiveList<T> {
         self.arena.get_mut(id).map(|node| &mut node.value)
     }
 
-    /// Inserts a value at the front and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the front and returns its [`SlotId`].
     ///
     /// # Example
     ///
@@ -477,7 +477,7 @@ impl<T> IntrusiveList<T> {
         self.push_front_with_epoch(value, 0)
     }
 
-    /// Inserts a value at the front with an epoch and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the front with an epoch and returns its [`SlotId`].
     ///
     /// # Example
     ///
@@ -507,7 +507,7 @@ impl<T> IntrusiveList<T> {
         id
     }
 
-    /// Inserts a value at the back and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the back and returns its [`SlotId`].
     ///
     /// # Example
     ///
@@ -524,7 +524,7 @@ impl<T> IntrusiveList<T> {
         self.push_back_with_epoch(value, 0)
     }
 
-    /// Inserts a value at the back with an epoch and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the back with an epoch and returns its [`SlotId`].
     ///
     /// # Example
     ///
@@ -906,7 +906,7 @@ impl<'a, T> Iterator for IntrusiveListIter<'a, T> {
     }
 }
 
-/// Iterator over [`SlotId`](crate::ds::SlotId)s from front to back.
+/// Iterator over [`SlotId`]s from front to back.
 pub struct IntrusiveListIdIter<'a, T> {
     list: &'a IntrusiveList<T>,
     current: Option<SlotId>,
@@ -1095,7 +1095,7 @@ impl<T> ConcurrentIntrusiveList<T> {
         list.contains(id)
     }
 
-    /// Inserts a value at the front and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the front and returns its [`SlotId`].
     ///
     /// # Example
     ///
@@ -1129,7 +1129,7 @@ impl<T> ConcurrentIntrusiveList<T> {
         Some(list.push_front_with_epoch(value, epoch))
     }
 
-    /// Inserts a value at the back and returns its [`SlotId`](crate::ds::SlotId).
+    /// Inserts a value at the back and returns its [`SlotId`].
     ///
     /// # Example
     ///

--- a/src/ds/intrusive_list.rs
+++ b/src/ds/intrusive_list.rs
@@ -1,35 +1,138 @@
-//! Intrusive doubly linked list backed by `SlotArena`.
+//! Intrusive doubly linked list backed by [`SlotArena`](crate::ds::SlotArena).
 //!
-//! Stores list nodes in a `SlotArena` and links them by `SlotId`, enabling
-//! stable handles and O(1) splice/move operations without pointer chasing.
+//! Stores list nodes in a [`SlotArena`](crate::ds::SlotArena) and links them via
+//! [`SlotId`](crate::ds::SlotId), enabling stable handles and O(1) splice/move
+//! operations. Ideal for LRU ordering, eviction queues, and policy metadata.
 //!
 //! ## Architecture
 //!
 //! ```text
-//!   arena (SlotArena<Node<T>>)
-//!   ┌────────┬─────────────────────────────────────────────┐
-//!   │ SlotId │ Node { value, prev, next }                  │
-//!   ├────────┼─────────────────────────────────────────────┤
-//!   │ id_1   │ { value: A, prev: None, next: Some(id_2) }  │
-//!   │ id_2   │ { value: B, prev: Some(id_1), next: id_3 }  │
-//!   │ id_3   │ { value: C, prev: Some(id_2), next: None }  │
-//!   └────────┴─────────────────────────────────────────────┘
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                        IntrusiveList Layout                                 │
+//! │                                                                             │
+//! │   ┌───────────────────────────────────────────────────────────────────┐    │
+//! │   │  arena: SlotArena<Node<T>>                                        │    │
+//! │   │                                                                   │    │
+//! │   │  ┌────────┬─────────────────────────────────────────────────┐   │    │
+//! │   │  │ SlotId │ Node { value, prev, next, epoch }               │   │    │
+//! │   │  ├────────┼─────────────────────────────────────────────────┤   │    │
+//! │   │  │ id_0   │ { "A", prev: None,      next: Some(id_1), 0 }   │   │    │
+//! │   │  │ id_1   │ { "B", prev: Some(id_0), next: Some(id_2), 0 }  │   │    │
+//! │   │  │ id_2   │ { "C", prev: Some(id_1), next: None,       0 }  │   │    │
+//! │   │  └────────┴─────────────────────────────────────────────────┘   │    │
+//! │   └───────────────────────────────────────────────────────────────────┘    │
+//! │                                                                             │
+//! │   Doubly Linked Structure:                                                 │
+//! │                                                                             │
+//! │       head                                                  tail           │
+//! │         │                                                    │             │
+//! │         ▼                                                    ▼             │
+//! │      ┌──────┐      ┌──────┐      ┌──────┐                               │
+//! │      │ id_0 │ ◄──► │ id_1 │ ◄──► │ id_2 │                               │
+//! │      │  "A" │      │  "B" │      │  "C" │                               │
+//! │      └──────┘      └──────┘      └──────┘                               │
+//! │        MRU                          LRU                                   │
+//! │       (front)                      (back)                                  │
+//! └─────────────────────────────────────────────────────────────────────────────┘
 //!
-//!   head ─► [id_1] ◄──► [id_2] ◄──► [id_3] ◄── tail
+//! Move to Front (LRU access pattern)
+//! ───────────────────────────────────
+//!   move_to_front(id_2):
+//!
+//!   Before:  head ──► [A] ◄──► [B] ◄──► [C] ◄── tail
+//!
+//!   1. Detach id_2:  [A] ◄──► [B]    [C]
+//!   2. Update tail:  [A] ◄──► [B] ◄── tail
+//!   3. Attach front: [C] ◄──► [A] ◄──► [B]
+//!   4. Update head:  head ──► [C]
+//!
+//!   After:   head ──► [C] ◄──► [A] ◄──► [B] ◄── tail
+//!
+//! List Variants
+//! ─────────────
+//!   ┌─────────────────────────────────────────────────────────────────────┐
+//!   │ IntrusiveList<T>            Single-threaded, direct &T access       │
+//!   ├─────────────────────────────────────────────────────────────────────┤
+//!   │ ConcurrentIntrusiveList<T>  Thread-safe via RwLock                  │
+//!   │                             Uses closures: get_with(id, |v| ...)    │
+//!   └─────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
+//! ## Key Components
+//!
+//! - [`IntrusiveList`]: Single-threaded doubly linked list
+//! - [`ConcurrentIntrusiveList`]: Thread-safe wrapper with `RwLock`
+//! - [`SlotId`](crate::ds::SlotId): Stable handle for O(1) node access
+//!
 //! ## Operations
-//! - `move_to_front(id)`: detach + attach to head
-//! - `move_to_back(id)`: detach + attach to tail
-//! - `remove(id)`: detach + free slot in arena
 //!
-//! ## Performance
-//! - `push_front` / `push_back`: O(1)
-//! - `pop_front` / `pop_back`: O(1)
-//! - `move_to_front` / `move_to_back`: O(1)
-//! - `iter`: O(n)
+//! | Operation       | Description                        | Complexity |
+//! |-----------------|------------------------------------|------------|
+//! | `push_front`    | Insert at head                     | O(1)       |
+//! | `push_back`     | Insert at tail                     | O(1)       |
+//! | `pop_front`     | Remove and return head             | O(1)       |
+//! | `pop_back`      | Remove and return tail             | O(1)       |
+//! | `move_to_front` | Move existing node to head         | O(1)       |
+//! | `move_to_back`  | Move existing node to tail         | O(1)       |
+//! | `remove`        | Remove node by SlotId              | O(1)       |
+//! | `get` / `get_mut` | Access value by SlotId           | O(1)       |
+//! | `iter`          | Iterate front to back              | O(n)       |
 //!
-//! `debug_validate_invariants()` is available in debug/test builds.
+//! ## Use Cases
+//!
+//! - **LRU cache ordering**: Move accessed items to front, evict from back
+//! - **FIFO queues**: Push to back, pop from front
+//! - **Eviction policies**: Track recency with O(1) reordering
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::IntrusiveList;
+//!
+//! let mut list = IntrusiveList::new();
+//!
+//! // Build LRU order: most recent at front
+//! let a = list.push_back("page_a");
+//! let b = list.push_back("page_b");
+//! let c = list.push_back("page_c");
+//!
+//! // Access "page_a" - move to front (MRU)
+//! list.move_to_front(a);
+//!
+//! // Order is now: page_a, page_b, page_c
+//! assert_eq!(list.front(), Some(&"page_a"));
+//! assert_eq!(list.back(), Some(&"page_c"));
+//!
+//! // Evict LRU (back)
+//! let evicted = list.pop_back();
+//! assert_eq!(evicted, Some("page_c"));
+//! ```
+//!
+//! ## Epoch Tracking
+//!
+//! Nodes can store an `epoch` value for versioning or timestamp tracking:
+//!
+//! ```
+//! use cachekit::ds::IntrusiveList;
+//!
+//! let mut list = IntrusiveList::new();
+//! let id = list.push_front_with_epoch("data", 42);
+//!
+//! assert_eq!(list.epoch(id), Some(42));
+//! list.set_epoch(id, 100);
+//! assert_eq!(list.epoch(id), Some(100));
+//! ```
+//!
+//! ## Thread Safety
+//!
+//! - [`IntrusiveList`]: Not thread-safe, use in single-threaded contexts
+//! - [`ConcurrentIntrusiveList`]: Thread-safe via `parking_lot::RwLock`
+//!
+//! ## Implementation Notes
+//!
+//! - Backed by [`SlotArena`](crate::ds::SlotArena) for stable handles
+//! - No pointer chasing; links are `SlotId` indices
+//! - `debug_validate_invariants()` available in debug/test builds
 use parking_lot::RwLock;
 
 use crate::ds::slot_arena::{SlotArena, SlotId};
@@ -42,8 +145,58 @@ struct Node<T> {
     epoch: u64,
 }
 
+/// Doubly linked list backed by [`SlotArena`](crate::ds::SlotArena).
+///
+/// Provides O(1) insertion, removal, and reordering operations. Each node
+/// is identified by a stable [`SlotId`](crate::ds::SlotId) that remains valid
+/// until the node is removed.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::IntrusiveList;
+///
+/// let mut list = IntrusiveList::new();
+///
+/// // Insert nodes
+/// let a = list.push_front("first");
+/// let b = list.push_back("second");
+/// let c = list.push_back("third");
+///
+/// // Access by position
+/// assert_eq!(list.front(), Some(&"first"));
+/// assert_eq!(list.back(), Some(&"third"));
+///
+/// // Reorder: move "third" to front
+/// list.move_to_front(c);
+/// assert_eq!(list.front(), Some(&"third"));
+///
+/// // Remove by handle
+/// assert_eq!(list.remove(b), Some("second"));
+/// assert_eq!(list.len(), 2);
+/// ```
+///
+/// # Use Case: LRU Eviction Order
+///
+/// ```
+/// use cachekit::ds::IntrusiveList;
+///
+/// let mut lru: IntrusiveList<&str> = IntrusiveList::new();
+///
+/// // Insert items (oldest at back)
+/// let page1 = lru.push_back("page1");
+/// let page2 = lru.push_back("page2");
+/// let page3 = lru.push_back("page3");
+///
+/// // Access page3 - move to front (most recently used)
+/// lru.move_to_front(page3);
+/// // Order: page3, page1, page2
+///
+/// // Evict LRU (back)
+/// let evicted = lru.pop_back().unwrap();
+/// assert_eq!(evicted, "page2");  // page2 is now oldest
+/// ```
 #[derive(Debug)]
-/// Intrusive list that stores nodes in a `SlotArena` and links them via `SlotId`.
 pub struct IntrusiveList<T> {
     arena: SlotArena<Node<T>>,
     head: Option<SlotId>,
@@ -52,6 +205,15 @@ pub struct IntrusiveList<T> {
 
 impl<T> IntrusiveList<T> {
     /// Creates an empty list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let list: IntrusiveList<i32> = IntrusiveList::new();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             arena: SlotArena::new(),
@@ -60,7 +222,16 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Creates an empty list with reserved node capacity.
+    /// Creates an empty list with pre-allocated node capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let list: IntrusiveList<String> = IntrusiveList::with_capacity(1000);
+    /// assert!(list.is_empty());
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             arena: SlotArena::with_capacity(capacity),
@@ -70,43 +241,140 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Returns the number of nodes in the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// assert_eq!(list.len(), 0);
+    ///
+    /// list.push_back(1);
+    /// list.push_back(2);
+    /// assert_eq!(list.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.arena.len()
     }
 
     /// Returns `true` if the list is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// assert!(list.is_empty());
+    ///
+    /// list.push_back(1);
+    /// assert!(!list.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.arena.is_empty()
     }
 
     /// Returns `true` if `id` is currently a node in this list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back("value");
+    ///
+    /// assert!(list.contains(id));
+    /// list.remove(id);
+    /// assert!(!list.contains(id));
+    /// ```
     pub fn contains(&self, id: SlotId) -> bool {
         self.arena.contains(id)
     }
 
-    /// Returns the value at the front (MRU) of the list.
+    /// Returns the value at the front (head/MRU) of the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// assert_eq!(list.front(), None);
+    ///
+    /// list.push_front("first");
+    /// list.push_back("second");
+    /// assert_eq!(list.front(), Some(&"first"));
+    /// ```
     pub fn front(&self) -> Option<&T> {
         self.head
             .and_then(|id| self.arena.get(id).map(|node| &node.value))
     }
 
-    /// Returns the SlotId at the front (MRU) of the list.
+    /// Returns the [`SlotId`](crate::ds::SlotId) at the front.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_front("value");
+    /// assert_eq!(list.front_id(), Some(id));
+    /// ```
     pub fn front_id(&self) -> Option<SlotId> {
         self.head
     }
 
-    /// Returns the value at the back (LRU) of the list.
+    /// Returns the value at the back (tail/LRU) of the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back("first");
+    /// list.push_back("second");
+    /// assert_eq!(list.back(), Some(&"second"));
+    /// ```
     pub fn back(&self) -> Option<&T> {
         self.tail
             .and_then(|id| self.arena.get(id).map(|node| &node.value))
     }
 
-    /// Returns the SlotId at the back (LRU) of the list.
+    /// Returns the [`SlotId`](crate::ds::SlotId) at the back.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back("first");
+    /// let id = list.push_back("second");
+    /// assert_eq!(list.back_id(), Some(id));
+    /// ```
     pub fn back_id(&self) -> Option<SlotId> {
         self.tail
     }
 
-    /// Returns an iterator from front to back.
+    /// Returns an iterator over values from front to back.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    /// list.push_back(3);
+    ///
+    /// let values: Vec<_> = list.iter().copied().collect();
+    /// assert_eq!(values, vec![1, 2, 3]);
+    /// ```
     pub fn iter(&self) -> IntrusiveListIter<'_, T> {
         IntrusiveListIter {
             list: self,
@@ -114,7 +382,20 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Returns an iterator of SlotIds from front to back.
+    /// Returns an iterator of [`SlotId`](crate::ds::SlotId)s from front to back.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let a = list.push_back("a");
+    /// let b = list.push_back("b");
+    ///
+    /// let ids: Vec<_> = list.iter_ids().collect();
+    /// assert_eq!(ids, vec![a, b]);
+    /// ```
     pub fn iter_ids(&self) -> IntrusiveListIdIter<'_, T> {
         IntrusiveListIdIter {
             list: self,
@@ -122,7 +403,21 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Returns an iterator of `(SlotId, &T)` from front to back.
+    /// Returns an iterator of `(SlotId, &T)` pairs from front to back.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let a = list.push_back("a");
+    /// let b = list.push_back("b");
+    ///
+    /// for (id, value) in list.iter_entries() {
+    ///     println!("id {:?} = {}", id, value);
+    /// }
+    /// ```
     pub fn iter_entries(&self) -> IntrusiveListEntryIter<'_, T> {
         IntrusiveListEntryIter {
             list: self,
@@ -130,22 +425,70 @@ impl<T> IntrusiveList<T> {
         }
     }
 
-    /// Returns the value for a node id, if present.
+    /// Returns the value for a node by its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back(42);
+    ///
+    /// assert_eq!(list.get(id), Some(&42));
+    /// ```
     pub fn get(&self, id: SlotId) -> Option<&T> {
         self.arena.get(id).map(|node| &node.value)
     }
 
-    /// Returns a mutable reference to a node value, if present.
+    /// Returns a mutable reference to a node's value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back(1);
+    ///
+    /// if let Some(v) = list.get_mut(id) {
+    ///     *v = 2;
+    /// }
+    /// assert_eq!(list.get(id), Some(&2));
+    /// ```
     pub fn get_mut(&mut self, id: SlotId) -> Option<&mut T> {
         self.arena.get_mut(id).map(|node| &mut node.value)
     }
 
-    /// Inserts a new node at the front and returns its `SlotId`.
+    /// Inserts a value at the front and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back("second");
+    /// list.push_front("first");
+    ///
+    /// assert_eq!(list.front(), Some(&"first"));
+    /// ```
     pub fn push_front(&mut self, value: T) -> SlotId {
         self.push_front_with_epoch(value, 0)
     }
 
-    /// Inserts a new node at the front with an epoch and returns its `SlotId`.
+    /// Inserts a value at the front with an epoch and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_front_with_epoch("data", 42);
+    ///
+    /// assert_eq!(list.epoch(id), Some(42));
+    /// ```
     pub fn push_front_with_epoch(&mut self, value: T, epoch: u64) -> SlotId {
         let id = self.arena.insert(Node {
             value,
@@ -164,12 +507,35 @@ impl<T> IntrusiveList<T> {
         id
     }
 
-    /// Inserts a new node at the back and returns its `SlotId`.
+    /// Inserts a value at the back and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back("first");
+    /// list.push_back("second");
+    ///
+    /// assert_eq!(list.back(), Some(&"second"));
+    /// ```
     pub fn push_back(&mut self, value: T) -> SlotId {
         self.push_back_with_epoch(value, 0)
     }
 
-    /// Inserts a new node at the back with an epoch and returns its `SlotId`.
+    /// Inserts a value at the back with an epoch and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back_with_epoch("data", 99);
+    ///
+    /// assert_eq!(list.epoch(id), Some(99));
+    /// ```
     pub fn push_back_with_epoch(&mut self, value: T, epoch: u64) -> SlotId {
         let id = self.arena.insert(Node {
             value,
@@ -189,11 +555,34 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Returns the epoch recorded for `id`, if present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_front_with_epoch("item", 5);
+    ///
+    /// assert_eq!(list.epoch(id), Some(5));
+    /// ```
     pub fn epoch(&self, id: SlotId) -> Option<u64> {
         self.arena.get(id).map(|node| node.epoch)
     }
 
     /// Sets the epoch for `id`; returns `false` if `id` is not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back("item");
+    ///
+    /// assert!(list.set_epoch(id, 10));
+    /// assert_eq!(list.epoch(id), Some(10));
+    /// ```
     pub fn set_epoch(&mut self, id: SlotId, epoch: u64) -> bool {
         if let Some(node) = self.arena.get_mut(id) {
             node.epoch = epoch;
@@ -204,6 +593,20 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Removes and returns the front value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// assert_eq!(list.pop_front(), Some(1));
+    /// assert_eq!(list.pop_front(), Some(2));
+    /// assert_eq!(list.pop_front(), None);
+    /// ```
     pub fn pop_front(&mut self) -> Option<T> {
         let id = self.head?;
         self.detach(id)?;
@@ -211,19 +614,67 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Removes and returns the back value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// assert_eq!(list.pop_back(), Some(2));
+    /// assert_eq!(list.pop_back(), Some(1));
+    /// assert_eq!(list.pop_back(), None);
+    /// ```
     pub fn pop_back(&mut self) -> Option<T> {
         let id = self.tail?;
         self.detach(id)?;
         self.arena.remove(id).map(|node| node.value)
     }
 
-    /// Removes the node `id` from the list and returns its value.
+    /// Removes the node `id` and returns its value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let a = list.push_back("a");
+    /// let b = list.push_back("b");
+    /// let c = list.push_back("c");
+    ///
+    /// // Remove middle element
+    /// assert_eq!(list.remove(b), Some("b"));
+    /// let values: Vec<_> = list.iter().copied().collect();
+    /// assert_eq!(values, vec!["a", "c"]);
+    /// ```
     pub fn remove(&mut self, id: SlotId) -> Option<T> {
         self.detach(id)?;
         self.arena.remove(id).map(|node| node.value)
     }
 
     /// Moves an existing node to the front; returns `false` if `id` is not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// list.push_back("a");
+    /// list.push_back("b");
+    /// let c = list.push_back("c");
+    ///
+    /// // Move "c" to front
+    /// assert!(list.move_to_front(c));
+    /// assert_eq!(list.front(), Some(&"c"));
+    ///
+    /// let values: Vec<_> = list.iter().copied().collect();
+    /// assert_eq!(values, vec!["c", "a", "b"]);
+    /// ```
     pub fn move_to_front(&mut self, id: SlotId) -> bool {
         if !self.arena.contains(id) {
             return false;
@@ -237,6 +688,24 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Moves an existing node to the back; returns `false` if `id` is not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let a = list.push_back("a");
+    /// list.push_back("b");
+    /// list.push_back("c");
+    ///
+    /// // Move "a" to back
+    /// assert!(list.move_to_back(a));
+    /// assert_eq!(list.back(), Some(&"a"));
+    ///
+    /// let values: Vec<_> = list.iter().copied().collect();
+    /// assert_eq!(values, vec!["b", "c", "a"]);
+    /// ```
     pub fn move_to_back(&mut self, id: SlotId) -> bool {
         if !self.arena.contains(id) {
             return false;
@@ -250,6 +719,20 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Clears the list and frees all nodes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::new();
+    /// let id = list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// list.clear();
+    /// assert!(list.is_empty());
+    /// assert!(!list.contains(id));
+    /// ```
     pub fn clear(&mut self) {
         self.arena.clear();
         self.head = None;
@@ -257,12 +740,33 @@ impl<T> IntrusiveList<T> {
     }
 
     /// Clears the list and shrinks internal storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let mut list = IntrusiveList::with_capacity(100);
+    /// list.push_back(1);
+    /// list.clear_shrink();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn clear_shrink(&mut self) {
         self.clear();
         self.arena.shrink_to_fit();
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::IntrusiveList;
+    ///
+    /// let list: IntrusiveList<u64> = IntrusiveList::with_capacity(100);
+    /// let bytes = list.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         std::mem::size_of::<Self>() + self.arena.approx_bytes()
     }
@@ -385,6 +889,7 @@ impl<T> IntrusiveList<T> {
     }
 }
 
+/// Iterator over values from front to back.
 pub struct IntrusiveListIter<'a, T> {
     list: &'a IntrusiveList<T>,
     current: Option<SlotId>,
@@ -401,7 +906,7 @@ impl<'a, T> Iterator for IntrusiveListIter<'a, T> {
     }
 }
 
-/// Iterator over SlotIds from front to back.
+/// Iterator over [`SlotId`](crate::ds::SlotId)s from front to back.
 pub struct IntrusiveListIdIter<'a, T> {
     list: &'a IntrusiveList<T>,
     current: Option<SlotId>,
@@ -441,21 +946,93 @@ impl<T> Default for IntrusiveList<T> {
     }
 }
 
+/// Thread-safe [`IntrusiveList`] wrapper using `parking_lot::RwLock`.
+///
+/// Provides the same functionality as [`IntrusiveList`] but safe for concurrent
+/// access. Uses closure-based access (`get_with`, `front_with`) since references
+/// cannot outlive lock guards.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::ds::ConcurrentIntrusiveList;
+///
+/// let list = Arc::new(ConcurrentIntrusiveList::new());
+///
+/// // Insert from main thread
+/// let id = list.push_front(0);
+///
+/// // Spawn threads that move items
+/// let handles: Vec<_> = (0..4).map(|_| {
+///     let list = Arc::clone(&list);
+///     thread::spawn(move || {
+///         list.move_to_front(id);
+///         list.push_back(1);
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert_eq!(list.len(), 5);  // 1 original + 4 pushed
+/// ```
+///
+/// # Non-blocking Operations
+///
+/// All operations have `try_*` variants that return `None` if the lock
+/// cannot be acquired immediately:
+///
+/// ```
+/// use cachekit::ds::ConcurrentIntrusiveList;
+///
+/// let list = ConcurrentIntrusiveList::new();
+/// let id = list.push_front(42);
+///
+/// // Non-blocking read
+/// if let Some(val) = list.try_get_with(id, |v| *v) {
+///     assert_eq!(val, 42);
+/// }
+///
+/// // Non-blocking move
+/// if let Some(success) = list.try_move_to_front(id) {
+///     assert!(success);
+/// }
+/// ```
 #[derive(Debug)]
-/// Thread-safe wrapper around `IntrusiveList` using a `parking_lot::RwLock`.
 pub struct ConcurrentIntrusiveList<T> {
     inner: RwLock<IntrusiveList<T>>,
 }
 
 impl<T> ConcurrentIntrusiveList<T> {
     /// Creates an empty concurrent list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list: ConcurrentIntrusiveList<i32> = ConcurrentIntrusiveList::new();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(IntrusiveList::new()),
         }
     }
 
-    /// Creates an empty concurrent list with reserved node capacity.
+    /// Creates an empty concurrent list with pre-allocated capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list: ConcurrentIntrusiveList<String> = ConcurrentIntrusiveList::with_capacity(100);
+    /// assert!(list.is_empty());
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             inner: RwLock::new(IntrusiveList::with_capacity(capacity)),
@@ -463,210 +1040,414 @@ impl<T> ConcurrentIntrusiveList<T> {
     }
 
     /// Returns the number of nodes in the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// assert_eq!(list.len(), 0);
+    ///
+    /// list.push_back(1);
+    /// list.push_back(2);
+    /// assert_eq!(list.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         let list = self.inner.read();
         list.len()
     }
 
     /// Returns `true` if the list is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list: ConcurrentIntrusiveList<i32> = ConcurrentIntrusiveList::new();
+    /// assert!(list.is_empty());
+    ///
+    /// list.push_back(1);
+    /// assert!(!list.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         let list = self.inner.read();
         list.is_empty()
     }
 
     /// Returns `true` if `id` is currently a node in this list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_back("value");
+    ///
+    /// assert!(list.contains(id));
+    /// list.remove(id);
+    /// assert!(!list.contains(id));
+    /// ```
     pub fn contains(&self, id: SlotId) -> bool {
         let list = self.inner.read();
         list.contains(id)
     }
 
-    /// Inserts a value at the front and returns its `SlotId`.
+    /// Inserts a value at the front and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_front("value");
+    /// assert!(list.contains(id));
+    /// ```
     pub fn push_front(&self, value: T) -> SlotId {
         let mut list = self.inner.write();
         list.push_front(value)
     }
 
-    /// Tries to insert a value at the front without blocking.
+    /// Non-blocking version of [`push_front`](Self::push_front).
     pub fn try_push_front(&self, value: T) -> Option<SlotId> {
         let mut list = self.inner.try_write()?;
         Some(list.push_front(value))
     }
 
-    /// Inserts a value at the front with an epoch and returns its `SlotId`.
+    /// Inserts a value at the front with an epoch.
     pub fn push_front_with_epoch(&self, value: T, epoch: u64) -> SlotId {
         let mut list = self.inner.write();
         list.push_front_with_epoch(value, epoch)
     }
 
-    /// Tries to insert a value at the front with an epoch without blocking.
+    /// Non-blocking version of [`push_front_with_epoch`](Self::push_front_with_epoch).
     pub fn try_push_front_with_epoch(&self, value: T, epoch: u64) -> Option<SlotId> {
         let mut list = self.inner.try_write()?;
         Some(list.push_front_with_epoch(value, epoch))
     }
 
-    /// Inserts a value at the back and returns its `SlotId`.
+    /// Inserts a value at the back and returns its [`SlotId`](crate::ds::SlotId).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back("first");
+    /// list.push_back("second");
+    /// assert_eq!(list.back_with(|v| *v), Some("second"));
+    /// ```
     pub fn push_back(&self, value: T) -> SlotId {
         let mut list = self.inner.write();
         list.push_back(value)
     }
 
-    /// Tries to insert a value at the back without blocking.
+    /// Non-blocking version of [`push_back`](Self::push_back).
     pub fn try_push_back(&self, value: T) -> Option<SlotId> {
         let mut list = self.inner.try_write()?;
         Some(list.push_back(value))
     }
 
-    /// Inserts a value at the back with an epoch and returns its `SlotId`.
+    /// Inserts a value at the back with an epoch.
     pub fn push_back_with_epoch(&self, value: T, epoch: u64) -> SlotId {
         let mut list = self.inner.write();
         list.push_back_with_epoch(value, epoch)
     }
 
-    /// Tries to insert a value at the back with an epoch without blocking.
+    /// Non-blocking version of [`push_back_with_epoch`](Self::push_back_with_epoch).
     pub fn try_push_back_with_epoch(&self, value: T, epoch: u64) -> Option<SlotId> {
         let mut list = self.inner.try_write()?;
         Some(list.push_back_with_epoch(value, epoch))
     }
 
     /// Removes and returns the front value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// assert_eq!(list.pop_front(), Some(1));
+    /// ```
     pub fn pop_front(&self) -> Option<T> {
         let mut list = self.inner.write();
         list.pop_front()
     }
 
-    /// Tries to remove and return the front value without blocking.
+    /// Non-blocking version of [`pop_front`](Self::pop_front).
     pub fn try_pop_front(&self) -> Option<Option<T>> {
         let mut list = self.inner.try_write()?;
         Some(list.pop_front())
     }
 
     /// Removes and returns the back value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// assert_eq!(list.pop_back(), Some(2));
+    /// ```
     pub fn pop_back(&self) -> Option<T> {
         let mut list = self.inner.write();
         list.pop_back()
     }
 
-    /// Tries to remove and return the back value without blocking.
+    /// Non-blocking version of [`pop_back`](Self::pop_back).
     pub fn try_pop_back(&self) -> Option<Option<T>> {
         let mut list = self.inner.try_write()?;
         Some(list.pop_back())
     }
 
-    /// Removes the node `id` and returns its value, if present.
+    /// Removes the node `id` and returns its value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_back(42);
+    ///
+    /// assert_eq!(list.remove(id), Some(42));
+    /// assert_eq!(list.remove(id), None);  // Already removed
+    /// ```
     pub fn remove(&self, id: SlotId) -> Option<T> {
         let mut list = self.inner.write();
         list.remove(id)
     }
 
-    /// Tries to remove the node `id` without blocking.
+    /// Non-blocking version of [`remove`](Self::remove).
     pub fn try_remove(&self, id: SlotId) -> Option<Option<T>> {
         let mut list = self.inner.try_write()?;
         Some(list.remove(id))
     }
 
     /// Moves an existing node to the front; returns `false` if not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back("a");
+    /// let b = list.push_back("b");
+    ///
+    /// list.move_to_front(b);
+    /// assert_eq!(list.front_with(|v| *v), Some("b"));
+    /// ```
     pub fn move_to_front(&self, id: SlotId) -> bool {
         let mut list = self.inner.write();
         list.move_to_front(id)
     }
 
-    /// Tries to move a node to the front without blocking.
+    /// Non-blocking version of [`move_to_front`](Self::move_to_front).
     pub fn try_move_to_front(&self, id: SlotId) -> Option<bool> {
         let mut list = self.inner.try_write()?;
         Some(list.move_to_front(id))
     }
 
     /// Moves an existing node to the back; returns `false` if not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let a = list.push_back("a");
+    /// list.push_back("b");
+    ///
+    /// list.move_to_back(a);
+    /// assert_eq!(list.back_with(|v| *v), Some("a"));
+    /// ```
     pub fn move_to_back(&self, id: SlotId) -> bool {
         let mut list = self.inner.write();
         list.move_to_back(id)
     }
 
-    /// Tries to move a node to the back without blocking.
+    /// Non-blocking version of [`move_to_back`](Self::move_to_back).
     pub fn try_move_to_back(&self, id: SlotId) -> Option<bool> {
         let mut list = self.inner.try_write()?;
         Some(list.move_to_back(id))
     }
 
-    /// Runs `f` on a shared reference to the value at `id`, if present.
+    /// Runs a closure on a shared reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_back(vec![1, 2, 3]);
+    ///
+    /// let sum = list.get_with(id, |v| v.iter().sum::<i32>());
+    /// assert_eq!(sum, Some(6));
+    /// ```
     pub fn get_with<R>(&self, id: SlotId, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.read();
         list.get(id).map(f)
     }
 
-    /// Tries to run `f` on a shared reference to the value at `id` without blocking.
+    /// Non-blocking version of [`get_with`](Self::get_with).
     pub fn try_get_with<R>(&self, id: SlotId, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.try_read()?;
         list.get(id).map(f)
     }
 
-    /// Runs `f` on a mutable reference to the value at `id`, if present.
+    /// Runs a closure on a mutable reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_back(1);
+    ///
+    /// list.get_mut_with(id, |v| *v = 2);
+    /// assert_eq!(list.get_with(id, |v| *v), Some(2));
+    /// ```
     pub fn get_mut_with<R>(&self, id: SlotId, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut list = self.inner.write();
         list.get_mut(id).map(f)
     }
 
-    /// Tries to run `f` on a mutable reference to the value at `id` without blocking.
+    /// Non-blocking version of [`get_mut_with`](Self::get_mut_with).
     pub fn try_get_mut_with<R>(&self, id: SlotId, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut list = self.inner.try_write()?;
         list.get_mut(id).map(f)
     }
 
-    /// Runs `f` on a shared reference to the front value, if present.
+    /// Runs a closure on a shared reference to the front value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_front("first");
+    ///
+    /// assert_eq!(list.front_with(|v| *v), Some("first"));
+    /// ```
     pub fn front_with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.read();
         list.front().map(f)
     }
 
-    /// Tries to run `f` on a shared reference to the front value without blocking.
+    /// Non-blocking version of [`front_with`](Self::front_with).
     pub fn try_front_with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.try_read()?;
         list.front().map(f)
     }
 
-    /// Runs `f` on a shared reference to the back value, if present.
+    /// Runs a closure on a shared reference to the back value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back("first");
+    /// list.push_back("second");
+    ///
+    /// assert_eq!(list.back_with(|v| *v), Some("second"));
+    /// ```
     pub fn back_with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.read();
         list.back().map(f)
     }
 
-    /// Tries to run `f` on a shared reference to the back value without blocking.
+    /// Non-blocking version of [`back_with`](Self::back_with).
     pub fn try_back_with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
         let list = self.inner.try_read()?;
         list.back().map(f)
     }
 
     /// Returns the epoch recorded for `id`, if present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_front_with_epoch("item", 42);
+    ///
+    /// assert_eq!(list.epoch(id), Some(42));
+    /// ```
     pub fn epoch(&self, id: SlotId) -> Option<u64> {
         let list = self.inner.read();
         list.epoch(id)
     }
 
-    /// Tries to read the epoch for `id` without blocking.
+    /// Non-blocking version of [`epoch`](Self::epoch).
     pub fn try_epoch(&self, id: SlotId) -> Option<Option<u64>> {
         let list = self.inner.try_read()?;
         Some(list.epoch(id))
     }
 
     /// Sets the epoch for `id`; returns `false` if `id` is not present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// let id = list.push_back("item");
+    ///
+    /// assert!(list.set_epoch(id, 99));
+    /// assert_eq!(list.epoch(id), Some(99));
+    /// ```
     pub fn set_epoch(&self, id: SlotId, epoch: u64) -> bool {
         let mut list = self.inner.write();
         list.set_epoch(id, epoch)
     }
 
-    /// Tries to set the epoch for `id` without blocking.
+    /// Non-blocking version of [`set_epoch`](Self::set_epoch).
     pub fn try_set_epoch(&self, id: SlotId, epoch: u64) -> Option<bool> {
         let mut list = self.inner.try_write()?;
         Some(list.set_epoch(id, epoch))
     }
 
     /// Clears the list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::new();
+    /// list.push_back(1);
+    /// list.push_back(2);
+    ///
+    /// list.clear();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn clear(&self) {
         let mut list = self.inner.write();
         list.clear();
     }
 
-    /// Tries to clear the list without blocking.
+    /// Non-blocking version of [`clear`](Self::clear).
     pub fn try_clear(&self) -> bool {
         if let Some(mut list) = self.inner.try_write() {
             list.clear();
@@ -677,12 +1458,24 @@ impl<T> ConcurrentIntrusiveList<T> {
     }
 
     /// Clears the list and shrinks internal storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list = ConcurrentIntrusiveList::with_capacity(100);
+    /// list.push_back(1);
+    ///
+    /// list.clear_shrink();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn clear_shrink(&self) {
         let mut list = self.inner.write();
         list.clear_shrink();
     }
 
-    /// Tries to clear and shrink without blocking.
+    /// Non-blocking version of [`clear_shrink`](Self::clear_shrink).
     pub fn try_clear_shrink(&self) -> bool {
         if let Some(mut list) = self.inner.try_write() {
             list.clear_shrink();
@@ -693,6 +1486,16 @@ impl<T> ConcurrentIntrusiveList<T> {
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentIntrusiveList;
+    ///
+    /// let list: ConcurrentIntrusiveList<u64> = ConcurrentIntrusiveList::with_capacity(100);
+    /// let bytes = list.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         let list = self.inner.read();
         list.approx_bytes()

--- a/src/ds/shard.rs
+++ b/src/ds/shard.rs
@@ -1,9 +1,122 @@
 //! Shared sharding helpers for consistent shard selection.
+//!
+//! Provides deterministic key-to-shard mapping used by sharded data structures
+//! like [`ShardedSlotArena`](crate::ds::ShardedSlotArena) and
+//! [`ShardedHashMapStore`](crate::store::ShardedHashMapStore).
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │                         Shard Selection Flow                           │
+//! │                                                                         │
+//! │   Input Key                                                             │
+//! │       │                                                                 │
+//! │       ▼                                                                 │
+//! │   ┌───────────────────────────────────────────────────────────────┐   │
+//! │   │  ShardSelector { shards: 4, seed: 42 }                        │   │
+//! │   │                                                               │   │
+//! │   │  1. Create DefaultHasher                                      │   │
+//! │   │  2. Hash seed: 42.hash(&mut hasher)                          │   │
+//! │   │  3. Hash key:  key.hash(&mut hasher)                         │   │
+//! │   │  4. Compute:   hasher.finish() % 4                           │   │
+//! │   │                                                               │   │
+//! │   └───────────────────────────────────────────────────────────────┘   │
+//! │       │                                                                 │
+//! │       ▼                                                                 │
+//! │   Shard Index: 0, 1, 2, or 3                                           │
+//! │                                                                         │
+//! │   ┌─────────┬─────────┬─────────┬─────────┐                           │
+//! │   │ Shard 0 │ Shard 1 │ Shard 2 │ Shard 3 │                           │
+//! │   │  keys   │  keys   │  keys   │  keys   │                           │
+//! │   │  A, E   │  B, F   │  C, G   │  D, H   │                           │
+//! │   └─────────┴─────────┴─────────┴─────────┘                           │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//!
+//! Properties
+//! ──────────
+//! • Deterministic: Same (key, seed, shards) always yields same shard
+//! • Uniform: Keys distribute evenly across shards (given good Hash impl)
+//! • Seed isolation: Different seeds produce different distributions
+//! ```
+//!
+//! ## Key Concepts
+//!
+//! - **Deterministic mapping**: Given the same key, seed, and shard count,
+//!   `shard_for_key` always returns the same shard index
+//! - **Seed isolation**: Different seeds produce different key distributions,
+//!   useful for avoiding pathological hash collisions
+//! - **Uniform distribution**: Relies on `DefaultHasher` for even spread
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::ShardSelector;
+//!
+//! // Create selector for 4 shards with seed 0
+//! let selector = ShardSelector::new(4, 0);
+//!
+//! // Map keys to shards
+//! let shard_a = selector.shard_for_key(&"user:123");
+//! let shard_b = selector.shard_for_key(&"user:456");
+//!
+//! assert!(shard_a < 4);
+//! assert!(shard_b < 4);
+//!
+//! // Same key always maps to same shard
+//! assert_eq!(selector.shard_for_key(&"user:123"), shard_a);
+//! ```
+//!
+//! ## When to Use
+//!
+//! - Sharded caches and data structures
+//! - Consistent hashing for distributed systems
+//! - Load balancing across workers or partitions
+//!
+//! ## Performance
+//!
+//! - `shard_for_key`: O(1) with cost of hashing the key
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-/// Deterministic shard selector based on a hash seed.
+/// Deterministic shard selector using a seeded hash.
+///
+/// Maps any `Hash`able key to a shard index in `[0, shards)`. The same
+/// `(key, seed, shards)` tuple always produces the same result.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::ShardSelector;
+///
+/// let selector = ShardSelector::new(8, 42);
+///
+/// // Deterministic: same key → same shard
+/// let shard = selector.shard_for_key(&"my_key");
+/// assert_eq!(selector.shard_for_key(&"my_key"), shard);
+///
+/// // Different keys may map to different shards
+/// let shard_a = selector.shard_for_key(&"key_a");
+/// let shard_b = selector.shard_for_key(&"key_b");
+/// // shard_a and shard_b are both in [0, 8)
+/// ```
+///
+/// # Seed Isolation
+///
+/// Different seeds produce different mappings:
+///
+/// ```
+/// use cachekit::ds::ShardSelector;
+///
+/// let sel1 = ShardSelector::new(4, 100);
+/// let sel2 = ShardSelector::new(4, 200);
+///
+/// // Same key, different seeds → likely different shards
+/// let s1 = sel1.shard_for_key(&"test");
+/// let s2 = sel2.shard_for_key(&"test");
+/// // s1 and s2 may differ (not guaranteed, but probable)
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub struct ShardSelector {
     shards: usize,
@@ -11,7 +124,22 @@ pub struct ShardSelector {
 }
 
 impl ShardSelector {
-    /// Creates a selector for `shards` with a given `seed`.
+    /// Creates a selector for `shards` shards with the given `seed`.
+    ///
+    /// The shard count is clamped to at least 1.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardSelector;
+    ///
+    /// let selector = ShardSelector::new(16, 0);
+    /// assert_eq!(selector.shard_count(), 16);
+    ///
+    /// // Zero shards is clamped to 1
+    /// let single = ShardSelector::new(0, 0);
+    /// assert_eq!(single.shard_count(), 1);
+    /// ```
     pub fn new(shards: usize, seed: u64) -> Self {
         Self {
             shards: shards.max(1),
@@ -20,11 +148,41 @@ impl ShardSelector {
     }
 
     /// Returns the number of shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardSelector;
+    ///
+    /// let selector = ShardSelector::new(8, 0);
+    /// assert_eq!(selector.shard_count(), 8);
+    /// ```
     pub fn shard_count(&self) -> usize {
         self.shards
     }
 
     /// Maps a key to a shard index in `[0, shards)`.
+    ///
+    /// The mapping is deterministic: the same key always returns the same
+    /// shard index for a given selector configuration.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardSelector;
+    ///
+    /// let selector = ShardSelector::new(4, 0);
+    ///
+    /// let shard = selector.shard_for_key(&"user:alice");
+    /// assert!(shard < 4);
+    ///
+    /// // Deterministic
+    /// assert_eq!(selector.shard_for_key(&"user:alice"), shard);
+    ///
+    /// // Works with any Hash type
+    /// let int_shard = selector.shard_for_key(&12345_u64);
+    /// assert!(int_shard < 4);
+    /// ```
     pub fn shard_for_key<K: Hash>(&self, key: &K) -> usize {
         let mut hasher = DefaultHasher::new();
         self.seed.hash(&mut hasher);
@@ -34,6 +192,7 @@ impl ShardSelector {
 }
 
 impl Default for ShardSelector {
+    /// Creates a single-shard selector with seed 0.
     fn default() -> Self {
         Self::new(1, 0)
     }

--- a/src/ds/shard.rs
+++ b/src/ds/shard.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides deterministic key-to-shard mapping used by sharded data structures
 //! like [`ShardedSlotArena`](crate::ds::ShardedSlotArena) and
-//! [`ShardedHashMapStore`](crate::store::ShardedHashMapStore).
+//! [`ShardedHashMapStore`](crate::store::hashmap::ShardedHashMapStore).
 //!
 //! ## Architecture
 //!

--- a/src/ds/slot_arena.rs
+++ b/src/ds/slot_arena.rs
@@ -1,47 +1,247 @@
-//! Slot arena with stable `SlotId` handles.
+//! Slot arena with stable [`SlotId`] handles.
 //!
-//! Stores elements in a `Vec<Option<T>>` and reuses freed slots via a free list.
-//! This keeps indices stable and avoids per-operation allocation.
+//! Provides arena-style allocation where elements are stored in a `Vec<Option<T>>`
+//! and freed slots are tracked in a free list for reuse. Handles ([`SlotId`]) remain
+//! stable across insertions and deletions, making this ideal for graph structures,
+//! linked lists, and policy metadata.
 //!
 //! ## Architecture
 //!
 //! ```text
-//!   slots: Vec<Option<T>>
-//!   free_list: Vec<usize>
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                           SlotArena Layout                                  │
+//! │                                                                             │
+//! │   ┌───────────────────────────────────────────────────────────────────┐    │
+//! │   │  slots: Vec<Option<T>>                                            │    │
+//! │   │                                                                   │    │
+//! │   │    index:   0        1        2        3        4        5       │    │
+//! │   │           ┌────┐  ┌────┐  ┌────┐  ┌────┐  ┌────┐  ┌────┐        │    │
+//! │   │           │ T  │  │None│  │ T  │  │None│  │ T  │  │None│        │    │
+//! │   │           │"a" │  │    │  │"c" │  │    │  │"e" │  │    │        │    │
+//! │   │           └────┘  └────┘  └────┘  └────┘  └────┘  └────┘        │    │
+//! │   │              ▲       │       ▲       │       ▲       │           │    │
+//! │   │              │       │       │       │       │       │           │    │
+//! │   │           SlotId(0)  │   SlotId(2)   │   SlotId(4)   │           │    │
+//! │   │                      │               │               │           │    │
+//! │   └──────────────────────┼───────────────┼───────────────┼───────────┘    │
+//! │                          │               │               │                 │
+//! │   ┌──────────────────────┼───────────────┼───────────────┼───────────┐    │
+//! │   │  free_list: Vec<usize>               │               │           │    │
+//! │   │                      │               │               │           │    │
+//! │   │              ┌───────┴───────┬───────┴───────┬───────┴───────┐  │    │
+//! │   │              │       1       │       3       │       5       │  │    │
+//! │   │              └───────────────┴───────────────┴───────────────┘  │    │
+//! │   │                                                                  │    │
+//! │   │              ◄─────── pop() returns 5 for next insert ──────►   │    │
+//! │   └──────────────────────────────────────────────────────────────────┘    │
+//! │                                                                             │
+//! │   len: 3  (number of live entries, not slots.len())                        │
+//! └─────────────────────────────────────────────────────────────────────────────┘
 //!
-//!   index: 0     1     2     3
-//!          [T]  [ ]   [T]   [ ]
-//!                 ^         ^
-//!                 |         |
-//!             free_list = [1, 3]
+//! Slot Lifecycle
+//! ──────────────
+//!
+//!   insert("x"):
+//!     ├─► free_list.pop() ──► Some(idx) ──► slots[idx] = Some("x")
+//!     │                                      return SlotId(idx)
+//!     │
+//!     └─► None ──► slots.push(Some("x"))
+//!                  return SlotId(slots.len() - 1)
+//!
+//!   remove(SlotId(2)):
+//!     slots[2].take() ──► Some("c") ──► free_list.push(2)
+//!                                       return Some("c")
+//!
+//!   get(SlotId(2)):
+//!     slots.get(2) ──► Some(&slot) ──► slot.as_ref() ──► Option<&T>
+//!
+//! Arena Variants
+//! ──────────────
+//!
+//!   ┌─────────────────────────────────────────────────────────────────────┐
+//!   │ SlotArena<T>              Single-threaded, direct &T access         │
+//!   ├─────────────────────────────────────────────────────────────────────┤
+//!   │ ConcurrentSlotArena<T>    Thread-safe via RwLock                    │
+//!   │                           Uses closures: get_with(id, |v| ...)      │
+//!   ├─────────────────────────────────────────────────────────────────────┤
+//!   │ ShardedSlotArena<T>       Multiple RwLock-protected arenas          │
+//!   │                           Round-robin insert, ShardedSlotId handle  │
+//!   └─────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
+//! ## Key Components
+//!
+//! - [`SlotId`]: Stable handle wrapping a `usize` index
+//! - [`SlotArena`]: Single-threaded arena with O(1) operations
+//! - [`ConcurrentSlotArena`]: Thread-safe wrapper with closure-based access
+//! - [`ShardedSlotArena`]: Sharded arena for high-concurrency workloads
+//! - [`ShardedSlotId`]: Handle containing shard index + slot id
+//!
 //! ## Operations
-//! - `insert(value)`: uses a free slot if available, otherwise grows `slots`
-//! - `remove(id)`: clears slot and pushes index to `free_list`
-//! - `get(id)`: returns `None` if slot is empty or out of bounds
 //!
-//! ## Performance
-//! - `insert` / `remove` / `get`: O(1) average
-//! - `iter`: O(n) over slots
+//! | Operation     | Description                              | Complexity |
+//! |---------------|------------------------------------------|------------|
+//! | `insert`      | Add value, reuse free slot if available  | O(1)       |
+//! | `remove`      | Remove and return value, free the slot   | O(1)       |
+//! | `get`         | Get reference by SlotId                  | O(1)       |
+//! | `get_mut`     | Get mutable reference by SlotId          | O(1)       |
+//! | `contains`    | Check if SlotId is valid                 | O(1)       |
+//! | `iter`        | Iterate over live entries                | O(n)       |
 //!
-//! `debug_validate_invariants()` is available in debug/test builds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-/// Stable handle into a `SlotArena`.
+//! ## Performance Characteristics
+//!
+//! - **No per-operation allocation**: Slots are reused, Vec grows as needed
+//! - **Cache-friendly**: Elements stored contiguously in memory
+//! - **Stable handles**: SlotId values remain valid until removed
+//! - **O(1) operations**: All single-element operations are constant time
+//!
+//! ## When to Use
+//!
+//! - Intrusive data structures (linked lists, trees, graphs)
+//! - Policy metadata storage (LRU list nodes, frequency counters)
+//! - Any scenario requiring stable handles that survive mutations
+//! - Memory pools where allocation churn is a concern
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::ds::SlotArena;
+//!
+//! let mut arena = SlotArena::new();
+//!
+//! // Insert values and get stable handles
+//! let id_a = arena.insert("alice");
+//! let id_b = arena.insert("bob");
+//!
+//! // Access by handle
+//! assert_eq!(arena.get(id_a), Some(&"alice"));
+//!
+//! // Remove frees the slot
+//! assert_eq!(arena.remove(id_b), Some("bob"));
+//!
+//! // Next insert reuses freed slot
+//! let id_c = arena.insert("carol");
+//! assert_eq!(id_b.index(), id_c.index());  // Same underlying index
+//! ```
+//!
+//! ## Thread Safety
+//!
+//! - [`SlotArena`]: Not thread-safe, use in single-threaded contexts
+//! - [`ConcurrentSlotArena`]: Thread-safe via `parking_lot::RwLock`
+//! - [`ShardedSlotArena`]: Thread-safe with per-shard locks
+//!
+//! ## Implementation Notes
+//!
+//! - `SlotId` indices may be reused after removal
+//! - Accessing a stale `SlotId` returns `None` (not undefined behavior)
+//! - `len()` tracks live entries, not `slots.len()`
+//! - `debug_validate_invariants()` available in debug/test builds
+/// Stable handle into a [`SlotArena`].
 ///
-/// `SlotId` values remain valid until the referenced slot is removed; after
-/// removal, the numeric index may be reused by a later `insert`.
+/// A lightweight identifier (wrapping a `usize` index) that provides O(1)
+/// access to arena slots. Handles remain valid until the slot is removed;
+/// after removal, the index may be reused by a later `insert`.
+///
+/// # Stability
+///
+/// Unlike raw indices or pointers, `SlotId` values are semantically tied to
+/// the slot they reference. Accessing a removed slot returns `None` rather
+/// than causing undefined behavior.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::SlotArena;
+///
+/// let mut arena = SlotArena::new();
+/// let id = arena.insert(42);
+///
+/// // SlotId provides O(1) access
+/// assert_eq!(arena.get(id), Some(&42));
+///
+/// // Inspect raw index for debugging
+/// println!("Value stored at index {}", id.index());
+///
+/// // After removal, same index may be reused
+/// arena.remove(id);
+/// let new_id = arena.insert(100);
+/// assert_eq!(id.index(), new_id.index());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SlotId(pub(crate) usize);
 
 impl SlotId {
     /// Returns the underlying slot index.
+    ///
+    /// Useful for debugging, logging, or custom data structures that need
+    /// to work with raw indices.
     pub fn index(self) -> usize {
         self.0
     }
 }
 
+/// Single-threaded arena with stable [`SlotId`] handles and O(1) operations.
+///
+/// Stores values in a `Vec<Option<T>>` and reuses freed slots via a free list.
+/// Ideal for graph structures, linked lists, and policy metadata where stable
+/// handles are needed.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::SlotArena;
+///
+/// let mut arena = SlotArena::new();
+///
+/// // Insert returns stable handles
+/// let a = arena.insert("first");
+/// let b = arena.insert("second");
+/// let c = arena.insert("third");
+///
+/// assert_eq!(arena.len(), 3);
+/// assert_eq!(arena.get(b), Some(&"second"));
+///
+/// // Remove frees the slot
+/// arena.remove(b);
+/// assert_eq!(arena.len(), 2);
+/// assert_eq!(arena.get(b), None);
+///
+/// // Next insert reuses the freed slot
+/// let d = arena.insert("fourth");
+/// assert_eq!(b.index(), d.index());
+///
+/// // Iterate over live entries
+/// for (id, value) in arena.iter() {
+///     println!("{}: {}", id.index(), value);
+/// }
+/// ```
+///
+/// # Use Case: Intrusive Linked List
+///
+/// ```
+/// use cachekit::ds::{SlotArena, SlotId};
+///
+/// struct Node {
+///     value: i32,
+///     next: Option<SlotId>,
+/// }
+///
+/// let mut arena = SlotArena::new();
+///
+/// // Build a linked list: 1 -> 2 -> 3
+/// let c = arena.insert(Node { value: 3, next: None });
+/// let b = arena.insert(Node { value: 2, next: Some(c) });
+/// let a = arena.insert(Node { value: 1, next: Some(b) });
+///
+/// // Traverse
+/// let mut current = Some(a);
+/// while let Some(id) = current {
+///     let node = arena.get(id).unwrap();
+///     println!("{}", node.value);
+///     current = node.next;
+/// }
+/// ```
 #[derive(Debug)]
-/// Arena that stores values in reusable slots and returns stable `SlotId`s.
 pub struct SlotArena<T> {
     slots: Vec<Option<T>>,
     free_list: Vec<usize>,
@@ -50,6 +250,15 @@ pub struct SlotArena<T> {
 
 impl<T> SlotArena<T> {
     /// Creates an empty arena.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let arena: SlotArena<String> = SlotArena::new();
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             slots: Vec::new(),
@@ -58,7 +267,17 @@ impl<T> SlotArena<T> {
         }
     }
 
-    /// Creates an empty arena with reserved capacity for slots.
+    /// Creates an empty arena with pre-allocated capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let arena: SlotArena<i32> = SlotArena::with_capacity(100);
+    /// assert!(arena.capacity() >= 100);
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             slots: Vec::with_capacity(capacity),
@@ -67,7 +286,19 @@ impl<T> SlotArena<T> {
         }
     }
 
-    /// Inserts a value and returns its `SlotId`.
+    /// Inserts a value and returns its [`SlotId`].
+    ///
+    /// Reuses a freed slot if available, otherwise grows the internal Vec.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert("hello");
+    /// assert_eq!(arena.get(id), Some(&"hello"));
+    /// ```
     pub fn insert(&mut self, value: T) -> SlotId {
         let idx = if let Some(idx) = self.free_list.pop() {
             self.slots[idx] = Some(value);
@@ -80,7 +311,21 @@ impl<T> SlotArena<T> {
         SlotId(idx)
     }
 
-    /// Removes the value at `id` and returns it, or `None` if empty/out of bounds.
+    /// Removes and returns the value at `id`, freeing the slot for reuse.
+    ///
+    /// Returns `None` if the slot is empty or out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert(42);
+    ///
+    /// assert_eq!(arena.remove(id), Some(42));
+    /// assert_eq!(arena.remove(id), None);  // Already removed
+    /// ```
     pub fn remove(&mut self, id: SlotId) -> Option<T> {
         let slot = self.slots.get_mut(id.0)?;
         let value = slot.take()?;
@@ -89,17 +334,55 @@ impl<T> SlotArena<T> {
         Some(value)
     }
 
-    /// Returns a shared reference to the value at `id`, if present.
+    /// Returns a shared reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert("value");
+    ///
+    /// assert_eq!(arena.get(id), Some(&"value"));
+    /// ```
     pub fn get(&self, id: SlotId) -> Option<&T> {
         self.slots.get(id.0).and_then(|slot| slot.as_ref())
     }
 
-    /// Returns a mutable reference to the value at `id`, if present.
+    /// Returns a mutable reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert(1);
+    ///
+    /// if let Some(v) = arena.get_mut(id) {
+    ///     *v = 2;
+    /// }
+    /// assert_eq!(arena.get(id), Some(&2));
+    /// ```
     pub fn get_mut(&mut self, id: SlotId) -> Option<&mut T> {
         self.slots.get_mut(id.0).and_then(|slot| slot.as_mut())
     }
 
-    /// Returns `true` if `id` currently refers to a live slot.
+    /// Returns `true` if `id` refers to a live slot.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert(1);
+    ///
+    /// assert!(arena.contains(id));
+    /// arena.remove(id);
+    /// assert!(!arena.contains(id));
+    /// ```
     pub fn contains(&self, id: SlotId) -> bool {
         self.slots
             .get(id.0)
@@ -107,7 +390,19 @@ impl<T> SlotArena<T> {
             .unwrap_or(false)
     }
 
-    /// Returns `true` if the slot at `index` is in bounds and occupied.
+    /// Returns `true` if the raw `index` is in bounds and occupied.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let id = arena.insert("value");
+    ///
+    /// assert!(arena.contains_index(id.index()));
+    /// assert!(!arena.contains_index(999));
+    /// ```
     pub fn contains_index(&self, index: usize) -> bool {
         self.slots
             .get(index)
@@ -116,38 +411,124 @@ impl<T> SlotArena<T> {
     }
 
     /// Returns the number of live entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// assert_eq!(arena.len(), 0);
+    ///
+    /// arena.insert("a");
+    /// arena.insert("b");
+    /// assert_eq!(arena.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns `true` if the arena has no live entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// assert!(arena.is_empty());
+    ///
+    /// let id = arena.insert(1);
+    /// assert!(!arena.is_empty());
+    ///
+    /// arena.remove(id);
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
-    /// Returns the backing vector capacity (number of slots that can be held without realloc).
+    /// Returns the backing Vec capacity (slots that fit without reallocation).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let arena: SlotArena<i32> = SlotArena::with_capacity(100);
+    /// assert!(arena.capacity() >= 100);
+    /// ```
     pub fn capacity(&self) -> usize {
         self.slots.capacity()
     }
 
     /// Reserves capacity for at least `additional` more slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena: SlotArena<i32> = SlotArena::new();
+    /// arena.reserve_slots(100);
+    /// assert!(arena.capacity() >= 100);
+    /// ```
     pub fn reserve_slots(&mut self, additional: usize) {
         self.slots.reserve(additional);
     }
 
-    /// Shrinks internal storage to fit the current length.
+    /// Shrinks internal storage to fit the current state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena: SlotArena<i32> = SlotArena::with_capacity(1000);
+    /// arena.insert(1);
+    /// arena.shrink_to_fit();
+    /// // Capacity reduced (exact value is implementation-defined)
+    /// ```
     pub fn shrink_to_fit(&mut self) {
         self.slots.shrink_to_fit();
         self.free_list.shrink_to_fit();
     }
 
     /// Clears all entries and shrinks internal storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::with_capacity(100);
+    /// arena.insert("a");
+    /// arena.insert("b");
+    ///
+    /// arena.clear_shrink();
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn clear_shrink(&mut self) {
         self.clear();
         self.shrink_to_fit();
     }
 
     /// Removes all entries and resets internal state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let a = arena.insert("a");
+    /// let b = arena.insert("b");
+    ///
+    /// arena.clear();
+    /// assert!(arena.is_empty());
+    /// assert!(!arena.contains(a));
+    /// assert!(!arena.contains(b));
+    /// ```
     pub fn clear(&mut self) {
         self.slots.clear();
         self.free_list.clear();
@@ -155,6 +536,19 @@ impl<T> SlotArena<T> {
     }
 
     /// Iterates over live `(SlotId, &T)` pairs.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// arena.insert("a");
+    /// arena.insert("b");
+    ///
+    /// let values: Vec<_> = arena.iter().map(|(_, v)| *v).collect();
+    /// assert_eq!(values, vec!["a", "b"]);
+    /// ```
     pub fn iter(&self) -> impl Iterator<Item = (SlotId, &T)> {
         self.slots
             .iter()
@@ -162,7 +556,22 @@ impl<T> SlotArena<T> {
             .filter_map(|(idx, slot)| slot.as_ref().map(|value| (SlotId(idx), value)))
     }
 
-    /// Iterates over live SlotIds.
+    /// Iterates over live [`SlotId`]s only.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena = SlotArena::new();
+    /// let a = arena.insert("a");
+    /// let b = arena.insert("b");
+    /// arena.remove(a);
+    ///
+    /// let ids: Vec<_> = arena.iter_ids().collect();
+    /// assert_eq!(ids.len(), 1);
+    /// assert!(ids.contains(&b));
+    /// ```
     pub fn iter_ids(&self) -> impl Iterator<Item = SlotId> + '_ {
         self.slots
             .iter()
@@ -186,6 +595,18 @@ impl<T> SlotArena<T> {
     }
 
     /// Returns an approximate memory footprint in bytes.
+    ///
+    /// Includes the struct itself, slot storage, and free list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::SlotArena;
+    ///
+    /// let mut arena: SlotArena<u64> = SlotArena::with_capacity(100);
+    /// let bytes = arena.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
             + self.slots.capacity() * std::mem::size_of::<Option<T>>()
@@ -193,6 +614,7 @@ impl<T> SlotArena<T> {
     }
 
     #[cfg(any(test, debug_assertions))]
+    /// Validates internal invariants (debug/test builds only).
     pub fn debug_validate_invariants(&self) {
         let live_count = self.slots.iter().filter(|slot| slot.is_some()).count();
         assert_eq!(self.len, live_count);
@@ -218,8 +640,26 @@ pub struct SlotArenaSnapshot {
     pub live_ids: Vec<SlotId>,
 }
 
+/// Stable handle into a [`ShardedSlotArena`].
+///
+/// Contains both the shard index and the [`SlotId`] within that shard.
+/// Required for O(1) access since the shard must be known to locate the value.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::ds::ShardedSlotArena;
+///
+/// let arena = ShardedSlotArena::new(4);
+/// let id = arena.insert(42);
+///
+/// // Inspect shard and slot
+/// println!("Shard {}, Slot {}", id.shard(), id.slot().index());
+///
+/// // Access value
+/// assert_eq!(arena.get_with(id, |v| *v), Some(42));
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-/// Stable handle into a `ShardedSlotArena`.
 pub struct ShardedSlotId {
     shard: usize,
     slot: SlotId,
@@ -227,18 +667,76 @@ pub struct ShardedSlotId {
 
 impl ShardedSlotId {
     /// Returns the shard index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(4);
+    /// let id = arena.insert(42);
+    /// assert!(id.shard() < 4);
+    /// ```
     pub fn shard(self) -> usize {
         self.shard
     }
 
-    /// Returns the slot id within the shard.
+    /// Returns the [`SlotId`] within the shard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let id = arena.insert("value");
+    /// let slot = id.slot();
+    /// // slot.index() is the position within the shard
+    /// ```
     pub fn slot(self) -> SlotId {
         self.slot
     }
 }
 
+/// Thread-safe sharded arena with multiple `RwLock`-protected [`SlotArena`]s.
+///
+/// Distributes inserts across shards in round-robin fashion to reduce
+/// contention. Each shard has its own lock, so operations on different
+/// shards can proceed in parallel.
+///
+/// # Use Cases
+///
+/// - High-concurrency metadata storage
+/// - When a single `ConcurrentSlotArena` becomes a bottleneck
+/// - Workloads with many concurrent writers
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::ds::ShardedSlotArena;
+///
+/// let arena = Arc::new(ShardedSlotArena::new(4));
+///
+/// // Spawn writers
+/// let handles: Vec<_> = (0..4).map(|_| {
+///     let arena = Arc::clone(&arena);
+///     thread::spawn(move || {
+///         for i in 0..100 {
+///             arena.insert(i);
+///         }
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert_eq!(arena.len(), 400);
+/// assert_eq!(arena.shard_count(), 4);
+/// ```
 #[derive(Debug)]
-/// SlotArena sharded by a fixed number of `RwLock`-protected arenas.
 pub struct ShardedSlotArena<T> {
     shards: Vec<parking_lot::RwLock<SlotArena<T>>>,
     selector: crate::ds::ShardSelector,
@@ -246,7 +744,16 @@ pub struct ShardedSlotArena<T> {
 }
 
 impl<T> ShardedSlotArena<T> {
-    /// Creates a sharded arena with `shards` shards.
+    /// Creates a sharded arena with the specified number of shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::new(8);
+    /// assert_eq!(arena.shard_count(), 8);
+    /// ```
     pub fn new(shards: usize) -> Self {
         let shards = shards.max(1);
         let mut arenas = Vec::with_capacity(shards);
@@ -260,7 +767,17 @@ impl<T> ShardedSlotArena<T> {
         }
     }
 
-    /// Creates a sharded arena with `shards` shards, each pre-allocated to `capacity`.
+    /// Creates a sharded arena with pre-allocated capacity per shard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// // 4 shards, each pre-allocated for 1000 entries
+    /// let arena: ShardedSlotArena<String> = ShardedSlotArena::with_capacity(4, 1000);
+    /// assert_eq!(arena.shard_count(), 4);
+    /// ```
     pub fn with_capacity(shards: usize, capacity: usize) -> Self {
         let shards = shards.max(1);
         let mut arenas = Vec::with_capacity(shards);
@@ -274,12 +791,22 @@ impl<T> ShardedSlotArena<T> {
         }
     }
 
-    /// Creates a sharded arena with `shards`, each pre-allocated to `capacity_per_shard`.
+    /// Alias for [`with_capacity`](Self::with_capacity).
     pub fn with_shards(shards: usize, capacity_per_shard: usize) -> Self {
         Self::with_capacity(shards, capacity_per_shard)
     }
 
-    /// Creates a sharded arena with `shards`, `capacity_per_shard`, and a hash seed.
+    /// Creates a sharded arena with a custom hash seed for shard selection.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// // Custom seed for deterministic shard selection
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::with_shards_seed(4, 100, 42);
+    /// assert_eq!(arena.shard_count(), 4);
+    /// ```
     pub fn with_shards_seed(shards: usize, capacity_per_shard: usize, seed: u64) -> Self {
         let shards = shards.max(1);
         let mut arenas = Vec::with_capacity(shards);
@@ -295,17 +822,51 @@ impl<T> ShardedSlotArena<T> {
         }
     }
 
-    /// Returns the shard index for `key` using the configured selector.
+    /// Returns the shard index for a key using the configured hash selector.
+    ///
+    /// Useful for co-locating related data in the same shard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<String> = ShardedSlotArena::new(8);
+    /// let shard = arena.shard_for_key(&"my_key");
+    /// assert!(shard < 8);
+    /// ```
     pub fn shard_for_key<K: std::hash::Hash>(&self, key: &K) -> usize {
         self.selector.shard_for_key(key)
     }
 
     /// Returns the number of shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::new(16);
+    /// assert_eq!(arena.shard_count(), 16);
+    /// ```
     pub fn shard_count(&self) -> usize {
         self.shards.len()
     }
 
-    /// Inserts a value into a selected shard and returns its `ShardedSlotId`.
+    /// Inserts a value into the next shard (round-robin) and returns its handle.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let a = arena.insert("first");
+    /// let b = arena.insert("second");
+    ///
+    /// // Inserts alternate between shards
+    /// assert_ne!(a.shard(), b.shard());
+    /// ```
     pub fn insert(&self, value: T) -> ShardedSlotId {
         let shard = self
             .next_shard
@@ -316,25 +877,74 @@ impl<T> ShardedSlotArena<T> {
         ShardedSlotId { shard, slot }
     }
 
-    /// Removes the value at `id` and returns it, if present.
+    /// Removes and returns the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let id = arena.insert(42);
+    ///
+    /// assert_eq!(arena.remove(id), Some(42));
+    /// assert_eq!(arena.remove(id), None);  // Already removed
+    /// ```
     pub fn remove(&self, id: ShardedSlotId) -> Option<T> {
         let mut arena = self.shards.get(id.shard)?.write();
         arena.remove(id.slot)
     }
 
-    /// Runs `f` on a shared reference to the value at `id`, if present.
+    /// Runs a closure on a shared reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let id = arena.insert(vec![1, 2, 3]);
+    ///
+    /// let len = arena.get_with(id, |v| v.len());
+    /// assert_eq!(len, Some(3));
+    /// ```
     pub fn get_with<R>(&self, id: ShardedSlotId, f: impl FnOnce(&T) -> R) -> Option<R> {
         let arena = self.shards.get(id.shard)?.read();
         arena.get(id.slot).map(f)
     }
 
-    /// Runs `f` on a mutable reference to the value at `id`, if present.
+    /// Runs a closure on a mutable reference to the value at `id`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let id = arena.insert(10);
+    ///
+    /// arena.get_mut_with(id, |v| *v += 5);
+    /// assert_eq!(arena.get_with(id, |v| *v), Some(15));
+    /// ```
     pub fn get_mut_with<R>(&self, id: ShardedSlotId, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut arena = self.shards.get(id.shard)?.write();
         arena.get_mut(id.slot).map(f)
     }
 
-    /// Returns `true` if `id` currently refers to a live slot.
+    /// Returns `true` if `id` refers to a live slot.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// let id = arena.insert("value");
+    ///
+    /// assert!(arena.contains(id));
+    /// arena.remove(id);
+    /// assert!(!arena.contains(id));
+    /// ```
     pub fn contains(&self, id: ShardedSlotId) -> bool {
         self.shards
             .get(id.shard)
@@ -342,38 +952,105 @@ impl<T> ShardedSlotArena<T> {
             .unwrap_or(false)
     }
 
-    /// Returns the number of live entries across all shards.
+    /// Returns the total number of live entries across all shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(4);
+    /// arena.insert(1);
+    /// arena.insert(2);
+    /// arena.insert(3);
+    ///
+    /// assert_eq!(arena.len(), 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.shards.iter().map(|arena| arena.read().len()).sum()
     }
 
     /// Returns `true` if all shards are empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::new(2);
+    /// assert!(arena.is_empty());
+    ///
+    /// arena.insert(1);
+    /// assert!(!arena.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Reserves capacity for at least `additional` more slots in each shard.
+    /// Reserves capacity in each shard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::new(4);
+    /// arena.reserve_slots(100);  // Each shard gets 100 additional capacity
+    /// ```
     pub fn reserve_slots(&self, additional: usize) {
         for arena in &self.shards {
             arena.write().reserve_slots(additional);
         }
     }
 
-    /// Shrinks all shards to fit their current lengths.
+    /// Shrinks all shards to fit their current state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<i32> = ShardedSlotArena::with_capacity(4, 1000);
+    /// arena.insert(1);
+    /// arena.shrink_to_fit();
+    /// ```
     pub fn shrink_to_fit(&self) {
         for arena in &self.shards {
             arena.write().shrink_to_fit();
         }
     }
 
-    /// Clears all shards and shrinks internal storage.
+    /// Clears all shards and shrinks storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena = ShardedSlotArena::new(2);
+    /// arena.insert(1);
+    /// arena.insert(2);
+    ///
+    /// arena.clear_shrink();
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn clear_shrink(&self) {
         for arena in &self.shards {
             arena.write().clear_shrink();
         }
     }
 
-    /// Returns an approximate memory footprint in bytes.
+    /// Returns approximate memory footprint across all shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ShardedSlotArena;
+    ///
+    /// let arena: ShardedSlotArena<u64> = ShardedSlotArena::with_capacity(4, 100);
+    /// let bytes = arena.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         self.shards
             .iter()
@@ -388,112 +1065,357 @@ impl<T> Default for SlotArena<T> {
     }
 }
 
+/// Thread-safe [`SlotArena`] wrapper using `parking_lot::RwLock`.
+///
+/// Provides the same functionality as [`SlotArena`] but safe for concurrent
+/// access. Uses closure-based access (`get_with`, `get_mut_with`) since
+/// references cannot outlive lock guards.
+///
+/// For high-contention workloads, consider [`ShardedSlotArena`] instead.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::ds::ConcurrentSlotArena;
+///
+/// let arena = Arc::new(ConcurrentSlotArena::new());
+///
+/// // Insert from main thread
+/// let id = arena.insert(0);
+///
+/// // Spawn readers and writers
+/// let handles: Vec<_> = (0..4).map(|i| {
+///     let arena = Arc::clone(&arena);
+///     thread::spawn(move || {
+///         // Read
+///         let val = arena.get_with(id, |v| *v);
+///
+///         // Write (increment)
+///         arena.get_mut_with(id, |v| *v += 1);
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert_eq!(arena.get_with(id, |v| *v), Some(4));
+/// ```
 #[derive(Debug)]
-/// Thread-safe wrapper around `SlotArena` using a `parking_lot::RwLock`.
 pub struct ConcurrentSlotArena<T> {
     inner: parking_lot::RwLock<SlotArena<T>>,
 }
 
 impl<T> ConcurrentSlotArena<T> {
     /// Creates an empty concurrent arena.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<String> = ConcurrentSlotArena::new();
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             inner: parking_lot::RwLock::new(SlotArena::new()),
         }
     }
 
-    /// Creates an empty concurrent arena with reserved slot capacity.
+    /// Creates a concurrent arena with pre-allocated capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<i32> = ConcurrentSlotArena::with_capacity(1000);
+    /// assert!(arena.capacity() >= 1000);
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             inner: parking_lot::RwLock::new(SlotArena::with_capacity(capacity)),
         }
     }
 
-    /// Inserts a value and returns its `SlotId`.
+    /// Inserts a value and returns its [`SlotId`].
+    ///
+    /// Acquires write lock.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(42);
+    /// assert!(arena.contains(id));
+    /// ```
     pub fn insert(&self, value: T) -> SlotId {
         let mut arena = self.inner.write();
         arena.insert(value)
     }
 
-    /// Removes the value at `id` and returns it, if present.
+    /// Removes and returns the value at `id`.
+    ///
+    /// Acquires write lock.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(42);
+    ///
+    /// assert_eq!(arena.remove(id), Some(42));
+    /// assert_eq!(arena.remove(id), None);
+    /// ```
     pub fn remove(&self, id: SlotId) -> Option<T> {
         let mut arena = self.inner.write();
         arena.remove(id)
     }
 
-    /// Runs `f` on a shared reference to the value at `id`, if present.
+    /// Runs a closure on a shared reference to the value at `id`.
+    ///
+    /// Acquires read lock. The closure's return value is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(vec![1, 2, 3]);
+    ///
+    /// let sum = arena.get_with(id, |v| v.iter().sum::<i32>());
+    /// assert_eq!(sum, Some(6));
+    /// ```
     pub fn get_with<R>(&self, id: SlotId, f: impl FnOnce(&T) -> R) -> Option<R> {
         let arena = self.inner.read();
         arena.get(id).map(f)
     }
 
-    /// Tries to run `f` on a shared reference to the value at `id` without blocking.
+    /// Non-blocking version of [`get_with`](Self::get_with).
+    ///
+    /// Returns `None` if the lock cannot be acquired immediately.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(100);
+    ///
+    /// // Returns Some if lock is available
+    /// if let Some(val) = arena.try_get_with(id, |v| *v) {
+    ///     assert_eq!(val, 100);
+    /// }
+    /// ```
     pub fn try_get_with<R>(&self, id: SlotId, f: impl FnOnce(&T) -> R) -> Option<R> {
         let arena = self.inner.try_read()?;
         arena.get(id).map(f)
     }
 
-    /// Runs `f` on a mutable reference to the value at `id`, if present.
+    /// Runs a closure on a mutable reference to the value at `id`.
+    ///
+    /// Acquires write lock.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(1);
+    ///
+    /// arena.get_mut_with(id, |v| *v = 2);
+    /// assert_eq!(arena.get_with(id, |v| *v), Some(2));
+    /// ```
     pub fn get_mut_with<R>(&self, id: SlotId, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut arena = self.inner.write();
         arena.get_mut(id).map(f)
     }
 
-    /// Tries to run `f` on a mutable reference to the value at `id` without blocking.
+    /// Non-blocking version of [`get_mut_with`](Self::get_mut_with).
+    ///
+    /// Returns `None` if the lock cannot be acquired immediately.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert(5);
+    ///
+    /// // Attempt non-blocking write
+    /// if arena.try_get_mut_with(id, |v| *v += 1).is_some() {
+    ///     assert_eq!(arena.get_with(id, |v| *v), Some(6));
+    /// }
+    /// ```
     pub fn try_get_mut_with<R>(&self, id: SlotId, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         let mut arena = self.inner.try_write()?;
         arena.get_mut(id).map(f)
     }
 
-    /// Returns `true` if `id` currently refers to a live slot.
+    /// Returns `true` if `id` refers to a live slot.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let id = arena.insert("value");
+    ///
+    /// assert!(arena.contains(id));
+    /// arena.remove(id);
+    /// assert!(!arena.contains(id));
+    /// ```
     pub fn contains(&self, id: SlotId) -> bool {
         let arena = self.inner.read();
         arena.contains(id)
     }
 
     /// Returns the number of live entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// assert_eq!(arena.len(), 0);
+    ///
+    /// arena.insert(1);
+    /// arena.insert(2);
+    /// assert_eq!(arena.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         let arena = self.inner.read();
         arena.len()
     }
 
     /// Returns `true` if there are no live entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<i32> = ConcurrentSlotArena::new();
+    /// assert!(arena.is_empty());
+    ///
+    /// let id = arena.insert(1);
+    /// assert!(!arena.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         let arena = self.inner.read();
         arena.is_empty()
     }
 
-    /// Returns the backing vector capacity.
+    /// Returns the backing Vec capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<i32> = ConcurrentSlotArena::with_capacity(100);
+    /// assert!(arena.capacity() >= 100);
+    /// ```
     pub fn capacity(&self) -> usize {
         let arena = self.inner.read();
         arena.capacity()
     }
 
-    /// Reserves capacity for at least `additional` more slots.
+    /// Reserves capacity for additional slots.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<i32> = ConcurrentSlotArena::new();
+    /// arena.reserve_slots(100);
+    /// assert!(arena.capacity() >= 100);
+    /// ```
     pub fn reserve_slots(&self, additional: usize) {
         let mut arena = self.inner.write();
         arena.reserve_slots(additional);
     }
 
-    /// Shrinks internal storage to fit the current length.
+    /// Shrinks internal storage to fit current state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<i32> = ConcurrentSlotArena::with_capacity(1000);
+    /// arena.insert(1);
+    /// arena.shrink_to_fit();
+    /// ```
     pub fn shrink_to_fit(&self) {
         let mut arena = self.inner.write();
         arena.shrink_to_fit();
     }
 
-    /// Clears all entries and shrinks internal storage.
+    /// Clears all entries and shrinks storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::with_capacity(100);
+    /// arena.insert("a");
+    /// arena.insert("b");
+    ///
+    /// arena.clear_shrink();
+    /// assert!(arena.is_empty());
+    /// ```
     pub fn clear_shrink(&self) {
         let mut arena = self.inner.write();
         arena.clear_shrink();
     }
 
     /// Clears all entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena = ConcurrentSlotArena::new();
+    /// let a = arena.insert(1);
+    /// let b = arena.insert(2);
+    ///
+    /// arena.clear();
+    /// assert!(arena.is_empty());
+    /// assert!(!arena.contains(a));
+    /// ```
     pub fn clear(&self) {
         let mut arena = self.inner.write();
         arena.clear();
     }
 
-    /// Returns an approximate memory footprint in bytes.
+    /// Returns approximate memory footprint in bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::ds::ConcurrentSlotArena;
+    ///
+    /// let arena: ConcurrentSlotArena<u64> = ConcurrentSlotArena::with_capacity(100);
+    /// let bytes = arena.approx_bytes();
+    /// assert!(bytes > 0);
+    /// ```
     pub fn approx_bytes(&self) -> usize {
         let arena = self.inner.read();
         arena.approx_bytes()

--- a/src/policy/two_q.rs
+++ b/src/policy/two_q.rs
@@ -153,12 +153,15 @@ enum QueueKind {
     Protected,
 }
 
-/// Internal entry storing key, value, and queue membership.
+/// Internal entry storing key, value, queue membership, and list position.
 #[derive(Debug)]
 struct Entry<K, V> {
     key: K,
     value: V,
     queue: QueueKind,
+    /// SlotId of this entry's node in the probation or protected list.
+    /// None if not yet attached to any list.
+    list_node: Option<SlotId>,
 }
 
 /// LRU queue backed by an intrusive doubly-linked list.
@@ -491,23 +494,53 @@ where
     /// assert_eq!(cache.get(&"missing"), None);
     /// ```
     pub fn get(&mut self, key: &K) -> Option<&V> {
-        let id = self.index.get(key)?;
+        let store_id = *self.index.get(key)?;
 
-        let queue = self.store.get(*id)?.queue;
+        let entry = self.store.get(store_id)?;
+        let queue = entry.queue;
+        let list_node = entry.list_node;
+
         match queue {
             QueueKind::Probation => {
-                self.probation.remove(*id);
-                self.probation.push_front(*id);
-                if let Some(e) = self.store.get_mut(*id) {
-                    e.queue = QueueKind::Protected;
-                }
+                // Promote from probation FIFO to protected LRU
+                self.detach_from_probation(store_id, list_node);
+                self.attach_to_protected(store_id);
             },
             QueueKind::Protected => {
-                self.protected.move_to_front(*id);
+                if let Some(node_id) = list_node {
+                    self.protected.move_to_front(node_id);
+                }
             },
         }
 
-        self.store.get(*id).map(|e| &e.value)
+        self.store.get(store_id).map(|e| &e.value)
+    }
+
+    /// Detaches an entry from the probation list.
+    fn detach_from_probation(&mut self, store_id: SlotId, list_node: Option<SlotId>) {
+        if let Some(node_id) = list_node {
+            let _ = self.probation.remove(node_id);
+        }
+        if let Some(entry) = self.store.get_mut(store_id) {
+            entry.list_node = None;
+        }
+    }
+
+    /// Attaches an entry to the protected queue (LRU).
+    fn attach_to_protected(&mut self, store_id: SlotId) {
+        let node_id = self.protected.push_front(store_id);
+        if let Some(entry) = self.store.get_mut(store_id) {
+            entry.queue = QueueKind::Protected;
+            entry.list_node = Some(node_id);
+        }
+    }
+
+    /// Attaches an entry to the probation queue (FIFO).
+    fn attach_to_probation(&mut self, store_id: SlotId) {
+        let node_id = self.probation.push_back(store_id);
+        if let Some(entry) = self.store.get_mut(store_id) {
+            entry.list_node = Some(node_id);
+        }
     }
 
     /// Inserts or updates a key-value pair.
@@ -540,30 +573,42 @@ where
             return;
         }
 
+        // Evict BEFORE inserting to ensure space is available
+        self.evict_if_needed();
+
+        // Create entry with no list attachment yet
         let entry = Entry {
             key: key.clone(),
             value,
             queue: QueueKind::Probation,
+            list_node: None,
         };
-        let id = self.store.insert(entry);
+        let store_id = self.store.insert(entry);
 
+        // Add to index
         self.index
-            .try_insert(key, id)
+            .try_insert(key, store_id)
             .expect("Failed to insert entry");
-        self.probation.push_back(id);
 
-        self.evict_if_needed();
+        // Attach to probation queue
+        self.attach_to_probation(store_id);
     }
 
-    /// Evicts entries until within capacity.
+    /// Evicts entries until there is room for a new entry.
     fn evict_if_needed(&mut self) {
-        while self.len() > self.protected_cap {
+        while self.len() >= self.protected_cap {
             if self.probation.len() > self.probation_cap {
                 if let Some(id) = self.probation.pop_front() {
                     self.remove_id(id);
                 }
             } else if let Some(id) = self.protected.pop_back() {
                 self.remove_id(id);
+            } else if let Some(id) = self.probation.pop_front() {
+                // Fallback: evict from probation even if under cap
+                self.remove_id(id);
+            } else {
+                // No entries to evict
+                break;
             }
         }
     }
@@ -722,5 +767,898 @@ where
         self.store.clear();
         self.probation.clear();
         self.protected.list.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::CoreCache;
+
+    // ==============================================
+    // LruQueue Tests
+    // ==============================================
+
+    mod lru_queue_tests {
+        use super::*;
+
+        #[test]
+        fn new_queue_is_empty() {
+            let lru: LruQueue<i32> = LruQueue::new();
+            assert!(lru.is_empty());
+            assert_eq!(lru.len(), 0);
+        }
+
+        #[test]
+        fn default_creates_empty_queue() {
+            let lru: LruQueue<&str> = LruQueue::default();
+            assert!(lru.is_empty());
+        }
+
+        #[test]
+        fn insert_increases_length() {
+            let mut lru = LruQueue::new();
+            lru.insert(1);
+            assert_eq!(lru.len(), 1);
+            assert!(!lru.is_empty());
+
+            lru.insert(2);
+            lru.insert(3);
+            assert_eq!(lru.len(), 3);
+        }
+
+        #[test]
+        fn evict_returns_lru_item() {
+            let mut lru = LruQueue::new();
+            lru.insert("first");
+            lru.insert("second");
+            lru.insert("third");
+
+            // "first" is the LRU (inserted first, never touched)
+            assert_eq!(lru.evict(), Some("first"));
+            assert_eq!(lru.evict(), Some("second"));
+            assert_eq!(lru.evict(), Some("third"));
+            assert_eq!(lru.evict(), None);
+        }
+
+        #[test]
+        fn touch_moves_to_mru() {
+            let mut lru = LruQueue::new();
+            let first = lru.insert("first");
+            lru.insert("second");
+            lru.insert("third");
+
+            // Touch "first" - moves it to MRU
+            assert!(lru.touch(first));
+
+            // Now "second" is LRU
+            assert_eq!(lru.evict(), Some("second"));
+            assert_eq!(lru.evict(), Some("third"));
+            assert_eq!(lru.evict(), Some("first")); // "first" is now MRU, evicted last
+        }
+
+        #[test]
+        fn remove_returns_item() {
+            let mut lru = LruQueue::new();
+            let id = lru.insert("item");
+            assert_eq!(lru.len(), 1);
+
+            assert_eq!(lru.remove(id), Some("item"));
+            assert!(lru.is_empty());
+        }
+
+        #[test]
+        fn remove_from_middle() {
+            let mut lru = LruQueue::new();
+            lru.insert("first");
+            let middle = lru.insert("middle");
+            lru.insert("last");
+
+            assert_eq!(lru.remove(middle), Some("middle"));
+            assert_eq!(lru.len(), 2);
+
+            // Remaining items evict in LRU order
+            assert_eq!(lru.evict(), Some("first"));
+            assert_eq!(lru.evict(), Some("last"));
+        }
+
+        #[test]
+        fn evict_from_empty_returns_none() {
+            let mut lru: LruQueue<i32> = LruQueue::new();
+            assert_eq!(lru.evict(), None);
+        }
+
+        #[test]
+        fn push_front_alias_works() {
+            let mut lru = LruQueue::new();
+            lru.push_front("a");
+            lru.push_front("b");
+            assert_eq!(lru.len(), 2);
+            // "a" is LRU since "b" was pushed front after
+            assert_eq!(lru.pop_back(), Some("a"));
+        }
+
+        #[test]
+        fn move_to_front_alias_works() {
+            let mut lru = LruQueue::new();
+            let a = lru.insert("a");
+            lru.insert("b");
+
+            assert!(lru.move_to_front(a));
+            // Now "b" is LRU
+            assert_eq!(lru.pop_back(), Some("b"));
+        }
+    }
+
+    // ==============================================
+    // TwoQCore Basic Operations
+    // ==============================================
+
+    mod basic_operations {
+        use super::*;
+
+        #[test]
+        fn new_cache_is_empty() {
+            let cache: TwoQCore<&str, i32> = TwoQCore::new(100, 0.25);
+            assert!(cache.is_empty());
+            assert_eq!(cache.len(), 0);
+            assert_eq!(cache.capacity(), 100);
+        }
+
+        #[test]
+        fn insert_and_get() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            cache.insert("key1", "value1");
+
+            assert_eq!(cache.len(), 1);
+            assert_eq!(cache.get(&"key1"), Some(&"value1"));
+        }
+
+        #[test]
+        fn insert_multiple_items() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            cache.insert("a", 1);
+            cache.insert("b", 2);
+            cache.insert("c", 3);
+
+            assert_eq!(cache.len(), 3);
+            assert_eq!(cache.get(&"a"), Some(&1));
+            assert_eq!(cache.get(&"b"), Some(&2));
+            assert_eq!(cache.get(&"c"), Some(&3));
+        }
+
+        #[test]
+        fn get_missing_key_returns_none() {
+            let mut cache: TwoQCore<&str, i32> = TwoQCore::new(100, 0.25);
+            cache.insert("exists", 42);
+
+            assert_eq!(cache.get(&"missing"), None);
+        }
+
+        #[test]
+        fn update_existing_key() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            cache.insert("key", "initial");
+            cache.insert("key", "updated");
+
+            assert_eq!(cache.len(), 1);
+            assert_eq!(cache.get(&"key"), Some(&"updated"));
+        }
+
+        #[test]
+        fn contains_returns_correct_result() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            cache.insert("exists", 1);
+
+            assert!(cache.contains(&"exists"));
+            assert!(!cache.contains(&"missing"));
+        }
+
+        #[test]
+        fn contains_does_not_promote() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+            cache.insert("a".to_string(), 1);
+            cache.insert("b".to_string(), 2);
+            cache.insert("c".to_string(), 3);
+
+            // Contains check should not promote
+            assert!(cache.contains(&"a".to_string()));
+            assert!(cache.contains(&"b".to_string()));
+            assert!(cache.contains(&"c".to_string()));
+
+            // Fill up to trigger eviction
+            for i in 0..10 {
+                cache.insert(format!("new{}", i), i);
+            }
+
+            // Original items should be evicted (they were only in probation)
+            assert!(!cache.contains(&"a".to_string()));
+            assert!(!cache.contains(&"b".to_string()));
+            assert!(!cache.contains(&"c".to_string()));
+        }
+
+        #[test]
+        fn clear_removes_all_entries() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            cache.insert("a", 1);
+            cache.insert("b", 2);
+            cache.get(&"a"); // Promote "a" to protected
+
+            cache.clear();
+
+            assert!(cache.is_empty());
+            assert_eq!(cache.len(), 0);
+            assert!(!cache.contains(&"a"));
+            assert!(!cache.contains(&"b"));
+        }
+
+        #[test]
+        fn capacity_returns_correct_value() {
+            let cache: TwoQCore<i32, i32> = TwoQCore::new(500, 0.25);
+            assert_eq!(cache.capacity(), 500);
+        }
+    }
+
+    // ==============================================
+    // Queue Behavior (Probation vs Protected)
+    // ==============================================
+
+    mod queue_behavior {
+        use super::*;
+
+        #[test]
+        fn new_insert_goes_to_probation() {
+            let mut cache = TwoQCore::new(10, 0.3);
+            cache.insert("key", "value");
+
+            assert!(cache.contains(&"key"));
+            assert_eq!(cache.len(), 1);
+        }
+
+        #[test]
+        fn get_promotes_from_probation_to_protected() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+            cache.insert("key".to_string(), 0);
+
+            // First get promotes to protected
+            let _ = cache.get(&"key".to_string());
+
+            // Insert enough items to fill probation and exceed capacity
+            for i in 0..12 {
+                cache.insert(format!("new{}", i), i);
+            }
+
+            // "key" should still exist because it was promoted to protected
+            assert!(cache.contains(&"key".to_string()));
+        }
+
+        #[test]
+        fn item_in_protected_stays_in_protected() {
+            let mut cache = TwoQCore::new(10, 0.3);
+            cache.insert("key", "value");
+
+            // Promote to protected
+            cache.get(&"key");
+
+            // Access again - should stay in protected, move to MRU
+            cache.get(&"key");
+            cache.get(&"key");
+
+            assert_eq!(cache.get(&"key"), Some(&"value"));
+        }
+
+        #[test]
+        fn multiple_accesses_keep_item_alive() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+
+            cache.insert("hot".to_string(), 0);
+            cache.get(&"hot".to_string());
+
+            for i in 0..15 {
+                cache.insert(format!("cold{}", i), i);
+                cache.get(&"hot".to_string());
+            }
+
+            assert!(cache.contains(&"hot".to_string()));
+        }
+    }
+
+    // ==============================================
+    // Eviction Behavior
+    // ==============================================
+
+    mod eviction_behavior {
+        use super::*;
+
+        #[test]
+        fn eviction_occurs_when_over_capacity() {
+            let mut cache = TwoQCore::new(5, 0.2);
+
+            for i in 0..10 {
+                cache.insert(i, i * 10);
+            }
+
+            assert_eq!(cache.len(), 5);
+        }
+
+        #[test]
+        fn probation_evicts_fifo_order() {
+            let mut cache = TwoQCore::new(5, 0.4);
+
+            cache.insert("first", 1);
+            cache.insert("second", 2);
+            cache.insert("third", 3);
+            cache.insert("fourth", 4);
+            cache.insert("fifth", 5);
+            cache.insert("sixth", 6);
+
+            assert!(!cache.contains(&"first"));
+            assert_eq!(cache.len(), 5);
+        }
+
+        #[test]
+        fn protected_evicts_lru_when_probation_under_cap() {
+            let mut cache = TwoQCore::new(5, 0.4);
+
+            cache.insert("p1", 1);
+            cache.get(&"p1");
+            cache.insert("p2", 2);
+            cache.get(&"p2");
+            cache.insert("p3", 3);
+            cache.get(&"p3");
+
+            cache.insert("new1", 10);
+            cache.insert("new2", 20);
+            cache.insert("new3", 30);
+
+            assert!(!cache.contains(&"p1"));
+            assert_eq!(cache.len(), 5);
+        }
+
+        #[test]
+        fn scan_items_evicted_before_hot_items() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+
+            cache.insert("hot1".to_string(), 1);
+            cache.get(&"hot1".to_string());
+            cache.insert("hot2".to_string(), 2);
+            cache.get(&"hot2".to_string());
+
+            for i in 0..20 {
+                cache.insert(format!("scan{}", i), i);
+            }
+
+            assert!(cache.contains(&"hot1".to_string()));
+            assert!(cache.contains(&"hot2".to_string()));
+            assert_eq!(cache.len(), 10);
+        }
+
+        #[test]
+        fn eviction_removes_from_index() {
+            let mut cache = TwoQCore::new(3, 0.33);
+
+            cache.insert("a", 1);
+            cache.insert("b", 2);
+            cache.insert("c", 3);
+
+            assert!(cache.contains(&"a"));
+
+            cache.insert("d", 4);
+
+            assert!(!cache.contains(&"a"));
+            assert_eq!(cache.get(&"a"), None);
+        }
+    }
+
+    // ==============================================
+    // Scan Resistance
+    // ==============================================
+
+    mod scan_resistance {
+        use super::*;
+
+        #[test]
+        fn scan_does_not_pollute_protected() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            for i in 0..50 {
+                let key = format!("working{}", i);
+                cache.insert(key.clone(), i);
+                cache.get(&key);
+            }
+
+            for i in 0..200 {
+                cache.insert(format!("scan{}", i), i);
+            }
+
+            let mut working_set_hits = 0;
+            for i in 0..50 {
+                if cache.contains(&format!("working{}", i)) {
+                    working_set_hits += 1;
+                }
+            }
+
+            assert!(
+                working_set_hits >= 40,
+                "Working set should survive scan, but only {} items remained",
+                working_set_hits
+            );
+        }
+
+        #[test]
+        fn one_time_access_stays_in_probation() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+
+            cache.insert("once".to_string(), 1);
+
+            for i in 0..5 {
+                cache.insert(format!("other{}", i), i);
+            }
+
+            cache.get(&"once".to_string());
+
+            for i in 0..10 {
+                cache.insert(format!("new{}", i), i);
+            }
+
+            assert!(cache.contains(&"once".to_string()));
+        }
+
+        #[test]
+        fn repeated_scans_dont_evict_hot_items() {
+            let mut cache = TwoQCore::new(20, 0.25);
+
+            for i in 0..10 {
+                let key = format!("hot{}", i);
+                cache.insert(key.clone(), i);
+                cache.get(&key);
+                cache.get(&key);
+                cache.get(&key);
+            }
+
+            for scan in 0..3 {
+                for i in 0..30 {
+                    cache.insert(format!("scan{}_{}", scan, i), i);
+                }
+            }
+
+            let mut hot_survivors = 0;
+            for i in 0..10 {
+                if cache.contains(&format!("hot{}", i)) {
+                    hot_survivors += 1;
+                }
+            }
+
+            assert!(
+                hot_survivors >= 8,
+                "Hot items should survive scans, but only {} survived",
+                hot_survivors
+            );
+        }
+    }
+
+    // ==============================================
+    // CoreCache Trait Implementation
+    // ==============================================
+
+    mod core_cache_trait {
+        use super::*;
+
+        #[test]
+        fn trait_insert_returns_old_value() {
+            let mut cache: TwoQCore<&str, i32> = TwoQCore::new(100, 0.25);
+
+            let old = CoreCache::insert(&mut cache, "key", 1);
+            assert_eq!(old, None);
+
+            let old = CoreCache::insert(&mut cache, "key", 2);
+            assert_eq!(old, Some(1));
+
+            assert_eq!(CoreCache::get(&mut cache, &"key"), Some(&2));
+        }
+
+        #[test]
+        fn trait_get_works() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            CoreCache::insert(&mut cache, "key", 42);
+
+            assert_eq!(CoreCache::get(&mut cache, &"key"), Some(&42));
+            assert_eq!(CoreCache::get(&mut cache, &"missing"), None);
+        }
+
+        #[test]
+        fn trait_contains_works() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            CoreCache::insert(&mut cache, "key", 1);
+
+            assert!(CoreCache::contains(&cache, &"key"));
+            assert!(!CoreCache::contains(&cache, &"missing"));
+        }
+
+        #[test]
+        fn trait_len_and_capacity() {
+            let mut cache: TwoQCore<i32, i32> = TwoQCore::new(50, 0.25);
+
+            assert_eq!(CoreCache::len(&cache), 0);
+            assert_eq!(CoreCache::capacity(&cache), 50);
+
+            for i in 0..30 {
+                CoreCache::insert(&mut cache, i, i * 10);
+            }
+
+            assert_eq!(CoreCache::len(&cache), 30);
+        }
+
+        #[test]
+        fn trait_clear_works() {
+            let mut cache = TwoQCore::new(100, 0.25);
+            CoreCache::insert(&mut cache, "a", 1);
+            CoreCache::insert(&mut cache, "b", 2);
+
+            CoreCache::clear(&mut cache);
+
+            assert_eq!(CoreCache::len(&cache), 0);
+            assert!(!CoreCache::contains(&cache, &"a"));
+        }
+    }
+
+    // ==============================================
+    // Edge Cases
+    // ==============================================
+
+    mod edge_cases {
+        use super::*;
+
+        #[test]
+        fn single_capacity_cache() {
+            let mut cache = TwoQCore::new(1, 0.5);
+
+            cache.insert("a", 1);
+            assert_eq!(cache.get(&"a"), Some(&1));
+
+            cache.insert("b", 2);
+            assert!(!cache.contains(&"a"));
+            assert_eq!(cache.get(&"b"), Some(&2));
+        }
+
+        #[test]
+        fn zero_probation_fraction() {
+            let mut cache = TwoQCore::new(10, 0.0);
+
+            for i in 0..10 {
+                cache.insert(i, i * 10);
+            }
+
+            assert_eq!(cache.len(), 10);
+
+            cache.insert(100, 1000);
+            assert_eq!(cache.len(), 10);
+        }
+
+        #[test]
+        fn one_hundred_percent_probation() {
+            let mut cache = TwoQCore::new(10, 1.0);
+
+            for i in 0..10 {
+                cache.insert(i, i * 10);
+            }
+
+            for i in 0..10 {
+                cache.get(&i);
+            }
+
+            assert_eq!(cache.len(), 10);
+        }
+
+        #[test]
+        fn get_after_update() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            cache.insert("key", "v1");
+            assert_eq!(cache.get(&"key"), Some(&"v1"));
+
+            cache.insert("key", "v2");
+            assert_eq!(cache.get(&"key"), Some(&"v2"));
+
+            cache.insert("key", "v3");
+            cache.insert("key", "v4");
+            assert_eq!(cache.get(&"key"), Some(&"v4"));
+        }
+
+        #[test]
+        fn large_capacity() {
+            let mut cache = TwoQCore::new(10000, 0.25);
+
+            for i in 0..10000 {
+                cache.insert(i, i * 2);
+            }
+
+            assert_eq!(cache.len(), 10000);
+
+            assert_eq!(cache.get(&5000), Some(&10000));
+            assert_eq!(cache.get(&9999), Some(&19998));
+        }
+
+        #[test]
+        fn empty_cache_operations() {
+            let mut cache: TwoQCore<i32, i32> = TwoQCore::new(100, 0.25);
+
+            assert!(cache.is_empty());
+            assert_eq!(cache.get(&1), None);
+            assert!(!cache.contains(&1));
+
+            cache.clear();
+            assert!(cache.is_empty());
+        }
+
+        #[test]
+        fn small_fractions() {
+            let mut cache = TwoQCore::new(100, 0.01);
+
+            for i in 0..10 {
+                cache.insert(i, i);
+            }
+
+            assert_eq!(cache.len(), 10);
+        }
+
+        #[test]
+        fn string_keys_and_values() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            cache.insert(String::from("hello"), String::from("world"));
+            cache.insert(String::from("foo"), String::from("bar"));
+
+            assert_eq!(
+                cache.get(&String::from("hello")),
+                Some(&String::from("world"))
+            );
+            assert_eq!(cache.get(&String::from("foo")), Some(&String::from("bar")));
+        }
+
+        #[test]
+        fn integer_keys() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            for i in 0..50 {
+                cache.insert(i, format!("value_{}", i));
+            }
+
+            assert_eq!(cache.get(&25), Some(&String::from("value_25")));
+            assert_eq!(cache.get(&49), Some(&String::from("value_49")));
+        }
+    }
+
+    // ==============================================
+    // Capacity and Eviction Boundary Tests
+    // ==============================================
+
+    mod boundary_tests {
+        use super::*;
+
+        #[test]
+        fn exact_capacity_no_eviction() {
+            let mut cache = TwoQCore::new(10, 0.3);
+
+            for i in 0..10 {
+                cache.insert(i, i);
+            }
+
+            assert_eq!(cache.len(), 10);
+            for i in 0..10 {
+                assert!(cache.contains(&i));
+            }
+        }
+
+        #[test]
+        fn one_over_capacity_triggers_eviction() {
+            let mut cache = TwoQCore::new(10, 0.3);
+
+            for i in 0..10 {
+                cache.insert(i, i);
+            }
+
+            cache.insert(10, 10);
+
+            assert_eq!(cache.len(), 10);
+            assert!(!cache.contains(&0));
+            assert!(cache.contains(&10));
+        }
+
+        #[test]
+        fn probation_cap_boundary() {
+            let mut cache = TwoQCore::new(10, 0.3);
+
+            cache.insert("a", 1);
+            cache.insert("b", 2);
+            cache.insert("c", 3);
+
+            assert_eq!(cache.len(), 3);
+
+            cache.insert("d", 4);
+            assert_eq!(cache.len(), 4);
+
+            for key in &["a", "b", "c", "d"] {
+                assert!(cache.contains(key));
+            }
+        }
+
+        #[test]
+        fn promotion_fills_protected() {
+            let mut cache = TwoQCore::new(10, 0.3);
+
+            for i in 0..5 {
+                cache.insert(i, i);
+            }
+
+            for i in 0..5 {
+                cache.get(&i);
+            }
+
+            for i in 5..10 {
+                cache.insert(i, i);
+            }
+
+            assert_eq!(cache.len(), 10);
+
+            cache.insert(10, 10);
+            assert_eq!(cache.len(), 10);
+        }
+    }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    mod regression_tests {
+        use super::*;
+
+        #[test]
+        fn promotion_actually_moves_to_protected_queue() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(5, 0.4);
+
+            cache.insert("key".to_string(), 0);
+            cache.get(&"key".to_string());
+
+            cache.insert("p1".to_string(), 1);
+            cache.insert("p2".to_string(), 2);
+            cache.insert("p3".to_string(), 3);
+            cache.insert("p4".to_string(), 4);
+
+            assert!(
+                cache.contains(&"key".to_string()),
+                "Promoted item should be in protected queue and survive probation eviction"
+            );
+        }
+
+        #[test]
+        fn update_preserves_queue_position() {
+            let mut cache: TwoQCore<String, i32> = TwoQCore::new(10, 0.3);
+
+            cache.insert("key".to_string(), 1);
+            cache.get(&"key".to_string());
+
+            cache.insert("key".to_string(), 2);
+
+            assert_eq!(cache.get(&"key".to_string()), Some(&2));
+
+            for i in 0..15 {
+                cache.insert(format!("other{}", i), i);
+            }
+
+            assert!(cache.contains(&"key".to_string()));
+        }
+
+        #[test]
+        fn eviction_order_consistency() {
+            for _ in 0..10 {
+                let mut cache = TwoQCore::new(5, 0.4);
+
+                cache.insert("a", 1);
+                cache.insert("b", 2);
+                cache.insert("c", 3);
+                cache.insert("d", 4);
+                cache.insert("e", 5);
+                cache.insert("f", 6);
+
+                assert!(!cache.contains(&"a"), "First item should be evicted");
+                assert!(cache.contains(&"f"), "New item should exist");
+            }
+        }
+    }
+
+    // ==============================================
+    // Workload Simulation
+    // ==============================================
+
+    mod workload_simulation {
+        use super::*;
+
+        #[test]
+        fn database_buffer_pool_workload() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            for i in 0..10 {
+                let key = format!("index_page_{}", i);
+                cache.insert(key.clone(), format!("index_data_{}", i));
+                cache.get(&key);
+                cache.get(&key);
+            }
+
+            for i in 0..200 {
+                cache.insert(format!("table_page_{}", i), format!("row_data_{}", i));
+            }
+
+            let mut index_hits = 0;
+            for i in 0..10 {
+                if cache.contains(&format!("index_page_{}", i)) {
+                    index_hits += 1;
+                }
+            }
+
+            assert!(
+                index_hits >= 8,
+                "Index pages should survive table scan, got {} hits",
+                index_hits
+            );
+        }
+
+        #[test]
+        fn web_cache_simulation() {
+            let mut cache: TwoQCore<String, String> = TwoQCore::new(50, 0.3);
+
+            let popular = vec!["home", "about", "products", "contact"];
+            for page in &popular {
+                cache.insert(page.to_string(), format!("{}_content", page));
+                cache.get(&page.to_string());
+                cache.get(&page.to_string());
+            }
+
+            for i in 0..100 {
+                cache.insert(format!("blog_post_{}", i), format!("content_{}", i));
+            }
+
+            for page in &popular {
+                assert!(
+                    cache.contains(&page.to_string()),
+                    "Popular page '{}' should survive",
+                    page
+                );
+            }
+        }
+
+        #[test]
+        fn mixed_workload() {
+            let mut cache = TwoQCore::new(100, 0.25);
+
+            for i in 0..30 {
+                let key = format!("working_{}", i);
+                cache.insert(key.clone(), i);
+                cache.get(&key);
+            }
+
+            for round in 0..5 {
+                for i in (0..30).step_by(3) {
+                    cache.get(&format!("working_{}", i));
+                }
+
+                for i in 0..20 {
+                    cache.insert(format!("round_{}_{}", round, i), i);
+                }
+            }
+
+            let mut working_set_hits = 0;
+            for i in (0..30).step_by(3) {
+                if cache.contains(&format!("working_{}", i)) {
+                    working_set_hits += 1;
+                }
+            }
+
+            assert!(
+                working_set_hits >= 8,
+                "Frequently accessed working set should survive, got {} hits",
+                working_set_hits
+            );
+        }
     }
 }

--- a/src/policy/two_q.rs
+++ b/src/policy/two_q.rs
@@ -1,15 +1,159 @@
+//! Two-Queue (2Q) cache replacement policy.
+//!
+//! Implements the 2Q algorithm, which separates recently inserted items from
+//! frequently accessed items using two queues. This provides scan resistance
+//! by preventing one-time accesses from polluting the main cache.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                           TwoQCore<K, V> Layout                             │
+//! │                                                                             │
+//! │   ┌─────────────────────────────────────────────────────────────────────┐   │
+//! │   │  index: HashMapStore<K, SlotId>    store: SlotArena<Entry<K,V>>    │   │
+//! │   │                                                                     │   │
+//! │   │  ┌──────────┬──────────┐          ┌────────┬──────────────────┐   │   │
+//! │   │  │   Key    │  SlotId  │          │ SlotId │ Entry            │   │   │
+//! │   │  ├──────────┼──────────┤          ├────────┼──────────────────┤   │   │
+//! │   │  │  "page1" │   id_0   │──────────►│  id_0  │ key,val,Probation│   │   │
+//! │   │  │  "page2" │   id_1   │──────────►│  id_1  │ key,val,Protected│   │   │
+//! │   │  │  "page3" │   id_2   │──────────►│  id_2  │ key,val,Probation│   │   │
+//! │   │  └──────────┴──────────┘          └────────┴──────────────────┘   │   │
+//! │   └─────────────────────────────────────────────────────────────────────┘   │
+//! │                                                                             │
+//! │   ┌─────────────────────────────────────────────────────────────────────┐   │
+//! │   │                        Queue Organization                           │   │
+//! │   │                                                                     │   │
+//! │   │   PROBATION QUEUE (A1in - FIFO)          PROTECTED QUEUE (Am - LRU) │   │
+//! │   │   ┌─────────────────────────┐            ┌─────────────────────────┐│   │
+//! │   │   │ front               back│            │ MRU               LRU  ││   │
+//! │   │   │  ▼                    ▼ │            │  ▼                  ▼  ││   │
+//! │   │   │ [id_2] ◄──► [id_0] ◄──┤ │            │ [id_1] ◄──► [...] ◄──┤ ││   │
+//! │   │   │  new        older  evict│            │ hot          cold  evict││   │
+//! │   │   └─────────────────────────┘            └─────────────────────────┘│   │
+//! │   │                                                                     │   │
+//! │   │   • New items enter probation FIFO                                  │   │
+//! │   │   • Re-access promotes to protected LRU                             │   │
+//! │   │   • Eviction: probation first (if over cap), then protected LRU     │   │
+//! │   └─────────────────────────────────────────────────────────────────────┘   │
+//! │                                                                             │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!
+//! Insert Flow (new key)
+//! ──────────────────────
+//!
+//!   insert("new_key", value):
+//!     1. Check index - not found
+//!     2. Create Entry with QueueKind::Probation
+//!     3. Insert into store → get SlotId
+//!     4. Insert key→SlotId into index
+//!     5. Push SlotId to back of probation queue
+//!     6. Evict if over capacity
+//!
+//! Access Flow (existing key)
+//! ──────────────────────────
+//!
+//!   get("existing_key"):
+//!     1. Lookup SlotId in index
+//!     2. Check entry's queue kind:
+//!        - If Probation: promote to Protected (move to protected MRU)
+//!        - If Protected: move to MRU position
+//!     3. Return &value
+//!
+//! Eviction Flow
+//! ─────────────
+//!
+//!   evict_if_needed():
+//!     while len > protected_cap:
+//!       if probation.len > probation_cap:
+//!         evict from probation front (oldest)
+//!       else:
+//!         evict from protected back (LRU)
+//! ```
+//!
+//! ## Key Components
+//!
+//! - [`TwoQCore`]: Main 2Q cache implementation
+//! - [`TwoQWithGhost`]: 2Q with ghost list for tracking evicted keys
+//! - [`LruQueue`]: LRU queue wrapper around [`IntrusiveList`]
+//!
+//! ## Operations
+//!
+//! | Operation   | Time   | Notes                                      |
+//! |-------------|--------|--------------------------------------------|
+//! | `get`       | O(1)   | May promote from probation to protected    |
+//! | `insert`    | O(1)*  | *Amortized, may trigger evictions          |
+//! | `contains`  | O(1)   | Index lookup only                          |
+//! | `len`       | O(1)   | Returns total entries                      |
+//! | `clear`     | O(n)   | Clears all structures                      |
+//!
+//! ## Algorithm Properties
+//!
+//! - **Scan Resistance**: One-time accesses stay in probation, don't pollute protected
+//! - **Frequency Awareness**: Repeated access promotes to protected LRU
+//! - **Tunable**: `a1_frac` controls probation/protected size ratio
+//!
+//! ## Use Cases
+//!
+//! - Database buffer pools (scan-heavy workloads)
+//! - File system caches
+//! - Web caches with mixed access patterns
+//!
+//! ## Example Usage
+//!
+//! ```
+//! use cachekit::policy::two_q::TwoQCore;
+//!
+//! // Create 2Q cache: 100 total capacity, 25% for probation
+//! let mut cache = TwoQCore::new(100, 0.25);
+//!
+//! // Insert items (go to probation)
+//! cache.insert("page1", "content1");
+//! cache.insert("page2", "content2");
+//!
+//! // First access promotes to protected
+//! assert_eq!(cache.get(&"page1"), Some(&"content1"));
+//!
+//! // Second access keeps in protected (MRU position)
+//! assert_eq!(cache.get(&"page1"), Some(&"content1"));
+//!
+//! assert_eq!(cache.len(), 2);
+//! ```
+//!
+//! ## Thread Safety
+//!
+//! - [`TwoQCore`]: Not thread-safe, designed for single-threaded use
+//! - For concurrent access, wrap in external synchronization
+//!
+//! ## Implementation Notes
+//!
+//! - Probation uses FIFO ordering (push back, evict front)
+//! - Protected uses LRU ordering (MRU at front, evict from back)
+//! - Promotion from probation to protected happens on re-access
+//! - Default `a1_frac` of 0.25 means 25% of capacity for probation
+//!
+//! ## References
+//!
+//! - Johnson & Shasha, "2Q: A Low Overhead High Performance Buffer Management
+//!   Replacement Algorithm", VLDB 1994
+
 use crate::ds::{IntrusiveList, SlotArena, SlotId};
 use crate::store::hashmap::HashMapStore;
 use crate::store::traits::{StoreCore, StoreMut};
 use std::collections::VecDeque;
 use std::hash::Hash;
 
+/// Indicates which queue an entry resides in.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum QueueKind {
+    /// Entry is in the probation (A1in) FIFO queue.
     Probation,
+    /// Entry is in the protected (Am) LRU queue.
     Protected,
 }
 
+/// Internal entry storing key, value, and queue membership.
 #[derive(Debug)]
 struct Entry<K, V> {
     key: K,
@@ -17,11 +161,50 @@ struct Entry<K, V> {
     queue: QueueKind,
 }
 
+/// LRU queue backed by an intrusive doubly-linked list.
+///
+/// Provides O(1) insert, touch (move to front), and evict (pop back) operations.
+/// Used for the protected queue in 2Q where access frequency matters.
+///
+/// # Type Parameters
+///
+/// - `T`: Element type stored in the queue
+///
+/// # Example
+///
+/// ```
+/// use cachekit::policy::two_q::LruQueue;
+///
+/// let mut lru = LruQueue::new();
+///
+/// // Insert items (most recent at front)
+/// let id1 = lru.insert("page1");
+/// let id2 = lru.insert("page2");
+///
+/// assert_eq!(lru.len(), 2);
+///
+/// // Touch moves to MRU position
+/// lru.touch(id1);
+///
+/// // Evict LRU (page2, since page1 was touched)
+/// let evicted = lru.evict();
+/// assert_eq!(evicted, Some("page2"));
+/// ```
 #[derive(Debug)]
 pub struct LruQueue<T> {
     list: IntrusiveList<T>,
 }
 
+/// Two-Queue cache with ghost list for tracking evicted keys.
+///
+/// Extends [`TwoQCore`] with a ghost list that remembers recently evicted keys.
+/// This allows detecting when a previously evicted key is re-accessed, which
+/// can be used for adaptive tuning or admission decisions.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Clone + Eq + Hash`
+/// - `V`: Value type
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TwoQWithGhost<K, V> {
@@ -30,15 +213,61 @@ pub struct TwoQWithGhost<K, V> {
     ghost_list_cap: usize,
 }
 
+/// Core Two-Queue (2Q) cache implementation.
+///
+/// Implements the 2Q replacement algorithm with two queues:
+/// - **Probation (A1in)**: FIFO queue for newly inserted items
+/// - **Protected (Am)**: LRU queue for frequently accessed items
+///
+/// New items enter probation. Re-accessing an item in probation promotes it
+/// to protected. This provides scan resistance by keeping one-time accesses
+/// from polluting the main cache.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Clone + Eq + Hash`
+/// - `V`: Value type
+///
+/// # Example
+///
+/// ```
+/// use cachekit::policy::two_q::TwoQCore;
+///
+/// // 100 capacity, 25% probation
+/// let mut cache = TwoQCore::new(100, 0.25);
+///
+/// // Insert goes to probation
+/// cache.insert("key1", "value1");
+/// assert!(cache.contains(&"key1"));
+///
+/// // First get promotes to protected
+/// cache.get(&"key1");
+///
+/// // Update existing key
+/// cache.insert("key1", "new_value");
+/// assert_eq!(cache.get(&"key1"), Some(&"new_value"));
+/// ```
+///
+/// # Eviction Behavior
+///
+/// When capacity is exceeded:
+/// 1. If probation exceeds its cap, evict from probation front (oldest)
+/// 2. Otherwise, evict from protected back (LRU)
 #[derive(Debug)]
 pub struct TwoQCore<K, V> {
-    index: HashMapStore<K, SlotId>, // key → store id
+    /// Maps keys to their SlotId in the store.
+    index: HashMapStore<K, SlotId>,
+    /// Arena storing all entries.
     store: SlotArena<Entry<K, V>>,
 
-    probation: IntrusiveList<SlotId>, // FIFO probation
-    protected: LruQueue<SlotId>,      // LRU protected
+    /// FIFO queue for newly inserted items.
+    probation: IntrusiveList<SlotId>,
+    /// LRU queue for frequently accessed items.
+    protected: LruQueue<SlotId>,
 
+    /// Maximum size of the probation queue.
     probation_cap: usize,
+    /// Maximum total cache capacity.
     protected_cap: usize,
 }
 
@@ -49,46 +278,154 @@ impl<T> Default for LruQueue<T> {
 }
 
 impl<T> LruQueue<T> {
+    /// Creates an empty LRU queue.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let lru: LruQueue<i32> = LruQueue::new();
+    /// assert!(lru.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             list: IntrusiveList::new(),
         }
     }
 
+    /// Returns `true` if the queue is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// assert!(lru.is_empty());
+    ///
+    /// lru.insert(42);
+    /// assert!(!lru.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.list.len() == 0
     }
 
+    /// Inserts an item at the MRU position (front).
+    ///
+    /// Returns the `SlotId` that can be used for future `touch` or `remove` calls.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// let id = lru.insert("page");
+    /// assert_eq!(lru.len(), 1);
+    /// ```
     pub fn insert(&mut self, id: T) -> SlotId {
         // new item is most-recently-used
         self.list.push_front(id)
     }
 
+    /// Moves an item to the MRU position (front).
+    ///
+    /// Returns `true` if the item was found and moved, `false` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// let id1 = lru.insert("old");
+    /// let id2 = lru.insert("new");
+    ///
+    /// // Touch makes "old" the MRU
+    /// assert!(lru.touch(id1));
+    ///
+    /// // Now "new" is LRU and will be evicted first
+    /// assert_eq!(lru.evict(), Some("new"));
+    /// ```
     pub fn touch(&mut self, id: SlotId) -> bool {
         // move accessed item to MRU position
         self.list.move_to_front(id)
     }
 
+    /// Removes and returns the LRU item (from back).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// lru.insert("first");
+    /// lru.insert("second");
+    ///
+    /// // "first" is LRU (inserted first, never touched)
+    /// assert_eq!(lru.evict(), Some("first"));
+    /// assert_eq!(lru.evict(), Some("second"));
+    /// assert_eq!(lru.evict(), None);
+    /// ```
     pub fn evict(&mut self) -> Option<T> {
         // remove least-recently-used
         self.list.pop_back()
     }
 
+    /// Removes an item by its `SlotId`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// let id = lru.insert("page");
+    ///
+    /// assert_eq!(lru.remove(id), Some("page"));
+    /// assert!(lru.is_empty());
+    /// ```
     pub fn remove(&mut self, id: SlotId) -> Option<T> {
         self.list.remove(id)
     }
 
+    /// Returns the number of items in the queue.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::LruQueue;
+    ///
+    /// let mut lru = LruQueue::new();
+    /// assert_eq!(lru.len(), 0);
+    ///
+    /// lru.insert(1);
+    /// lru.insert(2);
+    /// assert_eq!(lru.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.list.len()
     }
 
+    /// Pushes an item to the front (MRU position).
+    ///
+    /// Alias for [`insert`](Self::insert).
     pub fn push_front(&mut self, id: T) -> SlotId {
         self.list.push_front(id)
     }
 
+    /// Moves an item to the front (MRU position).
+    ///
+    /// Alias for [`touch`](Self::touch).
     pub fn move_to_front(&mut self, id: SlotId) -> bool {
         self.list.move_to_front(id)
     }
+
+    /// Removes and returns the item from the back (LRU position).
+    ///
+    /// Alias for [`evict`](Self::evict).
     pub fn pop_back(&mut self) -> Option<T> {
         self.list.pop_back()
     }
@@ -98,6 +435,25 @@ impl<K, V> TwoQCore<K, V>
 where
     K: Clone + Eq + Hash,
 {
+    /// Creates a new 2Q cache with the specified capacity and probation fraction.
+    ///
+    /// # Arguments
+    ///
+    /// - `protected_cap`: Total cache capacity (maximum number of entries)
+    /// - `a1_frac`: Fraction of capacity allocated to probation queue (0.0 to 1.0)
+    ///
+    /// A typical value for `a1_frac` is 0.25 (25% for probation).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// // 100 capacity, 25% probation (25 items max in probation)
+    /// let cache: TwoQCore<String, i32> = TwoQCore::new(100, 0.25);
+    /// assert_eq!(cache.capacity(), 100);
+    /// assert!(cache.is_empty());
+    /// ```
     pub fn new(protected_cap: usize, a1_frac: f64) -> Self {
         let probation_cap = (protected_cap as f64 * a1_frac) as usize;
 
@@ -111,6 +467,29 @@ where
         }
     }
 
+    /// Retrieves a value by key, promoting from probation to protected if needed.
+    ///
+    /// If the key is in probation, accessing it promotes the entry to the
+    /// protected queue (demonstrating it's not a one-time access).
+    /// If already in protected, moves it to the MRU position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache = TwoQCore::new(100, 0.25);
+    /// cache.insert("key", 42);
+    ///
+    /// // First access: in probation, now promotes to protected
+    /// assert_eq!(cache.get(&"key"), Some(&42));
+    ///
+    /// // Second access: already in protected, moves to MRU
+    /// assert_eq!(cache.get(&"key"), Some(&42));
+    ///
+    /// // Missing key
+    /// assert_eq!(cache.get(&"missing"), None);
+    /// ```
     pub fn get(&mut self, key: &K) -> Option<&V> {
         let id = self.index.get(key)?;
 
@@ -131,6 +510,28 @@ where
         self.store.get(*id).map(|e| &e.value)
     }
 
+    /// Inserts or updates a key-value pair.
+    ///
+    /// - If the key exists, updates the value in place (no queue change)
+    /// - If the key is new, inserts into the probation queue
+    /// - May trigger eviction if capacity is exceeded
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache = TwoQCore::new(100, 0.25);
+    ///
+    /// // New insert goes to probation
+    /// cache.insert("key", "initial");
+    /// assert_eq!(cache.len(), 1);
+    ///
+    /// // Update existing key
+    /// cache.insert("key", "updated");
+    /// assert_eq!(cache.get(&"key"), Some(&"updated"));
+    /// assert_eq!(cache.len(), 1);  // Still 1 entry
+    /// ```
     pub fn insert(&mut self, key: K, value: V) {
         if let Some(id) = self.index.get(&key) {
             if let Some(e) = self.store.get_mut(*id) {
@@ -154,6 +555,7 @@ where
         self.evict_if_needed();
     }
 
+    /// Evicts entries until within capacity.
     fn evict_if_needed(&mut self) {
         while self.len() > self.protected_cap {
             if self.probation.len() > self.probation_cap {
@@ -166,28 +568,96 @@ where
         }
     }
 
+    /// Removes an entry by its SlotId.
     fn remove_id(&mut self, id: SlotId) {
         if let Some(entry) = self.store.remove(id) {
             self.index.remove(&entry.key);
         }
     }
 
+    /// Returns the number of entries in the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache = TwoQCore::new(100, 0.25);
+    /// assert_eq!(cache.len(), 0);
+    ///
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    /// assert_eq!(cache.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.index.len()
     }
 
+    /// Returns `true` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache: TwoQCore<&str, i32> = TwoQCore::new(100, 0.25);
+    /// assert!(cache.is_empty());
+    ///
+    /// cache.insert("key", 42);
+    /// assert!(!cache.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.index.len() == 0
     }
 
+    /// Returns the total cache capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let cache: TwoQCore<String, i32> = TwoQCore::new(500, 0.25);
+    /// assert_eq!(cache.capacity(), 500);
+    /// ```
     pub fn capacity(&self) -> usize {
         self.protected_cap
     }
 
+    /// Returns `true` if the key exists in the cache.
+    ///
+    /// Does not affect queue positions (no promotion on contains).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache = TwoQCore::new(100, 0.25);
+    /// cache.insert("key", 42);
+    ///
+    /// assert!(cache.contains(&"key"));
+    /// assert!(!cache.contains(&"missing"));
+    /// ```
     pub fn contains(&self, key: &K) -> bool {
         self.index.contains(key)
     }
 
+    /// Clears all entries from the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::policy::two_q::TwoQCore;
+    ///
+    /// let mut cache = TwoQCore::new(100, 0.25);
+    /// cache.insert("a", 1);
+    /// cache.insert("b", 2);
+    ///
+    /// cache.clear();
+    /// assert!(cache.is_empty());
+    /// assert!(!cache.contains(&"a"));
+    /// ```
     pub fn clear(&mut self) {
         self.index.clear();
         self.store.clear();
@@ -196,6 +666,23 @@ where
     }
 }
 
+/// Implementation of the [`CoreCache`](crate::traits::CoreCache) trait for 2Q.
+///
+/// Allows `TwoQCore` to be used through the unified cache interface.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::CoreCache;
+/// use cachekit::policy::two_q::TwoQCore;
+///
+/// let mut cache: TwoQCore<&str, i32> = TwoQCore::new(100, 0.25);
+///
+/// // Use via CoreCache trait
+/// assert_eq!(CoreCache::insert(&mut cache, "key", 42), None);
+/// assert_eq!(CoreCache::get(&mut cache, &"key"), Some(&42));
+/// assert!(CoreCache::contains(&cache, &"key"));
+/// ```
 impl<K, V> crate::traits::CoreCache<K, V> for TwoQCore<K, V>
 where
     K: Clone + Eq + Hash,

--- a/src/store/handle.rs
+++ b/src/store/handle.rs
@@ -1,64 +1,138 @@
 //! Handle-based store for zero-copy policy metadata.
 //!
+//! Stores values keyed by compact handles (e.g., interner IDs) rather than
+//! full keys. This avoids cloning large keys while providing O(1) access
+//! via `HashMap<Handle, Arc<V>>`.
+//!
 //! ## Architecture
-//! - Stores values keyed by compact handles (e.g., interner IDs).
-//! - A `HashMap<Handle, Arc<V>>` provides O(1) access.
-//! - Policies operate on handles; the interner maps handles back to keys.
 //!
 //! ```text
-//! key -> KeyInterner -> handle -> policy/DS -> eviction -> handle -> KeyInterner -> key
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                        Handle-Based Storage Flow                            │
+//! │                                                                             │
+//! │   User Key                                                                  │
+//! │      │                                                                      │
+//! │      ▼                                                                      │
+//! │  ┌────────────────┐         ┌─────────────────┐         ┌──────────────┐   │
+//! │  │  KeyInterner   │────────►│     Handle      │────────►│ HandleStore  │   │
+//! │  │  (K -> Handle) │  intern │  (u64 / usize)  │   key   │ HashMap<H,V> │   │
+//! │  └────────────────┘         └─────────────────┘         └──────────────┘   │
+//! │         ▲                          │                           │           │
+//! │         │                          │                           │           │
+//! │         │                          ▼                           ▼           │
+//! │         │                   ┌─────────────────┐         ┌──────────────┐   │
+//! │         │                   │  Policy Layer   │         │   Arc<V>     │   │
+//! │         │                   │  (LRU, LFU...)  │         │   (value)    │   │
+//! │         │                   └─────────────────┘         └──────────────┘   │
+//! │         │                          │                                       │
+//! │         │  resolve                 │ evict handle                          │
+//! │         └──────────────────────────┘                                       │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!
+//! Data Flow
+//! ─────────
+//!
+//!   INSERT:  key ──► interner.intern() ──► handle ──► store.try_insert(handle, Arc<V>)
+//!
+//!   LOOKUP:  key ──► interner.get_handle() ──► handle ──► store.get(handle) ──► Arc<V>
+//!
+//!   EVICT:   policy.evict() ──► handle ──► store.remove(handle)
+//!                                  │
+//!                                  └──► interner.resolve(handle) ──► key (for callbacks)
+//!
+//! Component Relationships
+//! ───────────────────────
+//!
+//!   ┌──────────────────┐
+//!   │   HandleStore    │  Single-threaded, Cell-based metrics
+//!   │   (not Sync)     │  Direct HashMap access
+//!   └──────────────────┘
+//!
+//!   ┌──────────────────────────┐
+//!   │  ConcurrentHandleStore   │  Thread-safe via parking_lot::RwLock
+//!   │  (Send + Sync)           │  Atomic metrics counters
+//!   │  impl ConcurrentStore    │  Implements trait from store::traits
+//!   └──────────────────────────┘
 //! ```
 //!
 //! ## Key Components
-//! - `HandleStore`: single-threaded handle-backed store.
-//! - `ConcurrentHandleStore`: thread-safe wrapper using `RwLock`.
-//! - Metrics counters for hits/misses/updates/evictions.
+//!
+//! - [`HandleStore`]: Single-threaded handle-backed store with `Cell`-based metrics.
+//! - [`ConcurrentHandleStore`]: Thread-safe wrapper using `parking_lot::RwLock`.
+//! - Internal counters track hits, misses, inserts, updates, removes, evictions.
 //!
 //! ## Core Operations
-//! - `try_insert`: insert or update by handle.
-//! - `get`: fetch by handle (updates hit/miss metrics).
-//! - `remove`: delete by handle.
-//! - `clear`: drop all entries.
+//!
+//! | Operation     | Description                          | Complexity |
+//! |---------------|--------------------------------------|------------|
+//! | `try_insert`  | Insert or update by handle           | O(1) avg   |
+//! | `get`         | Fetch by handle (updates metrics)    | O(1) avg   |
+//! | `peek`        | Fetch without updating metrics       | O(1) avg   |
+//! | `remove`      | Delete by handle                     | O(1) avg   |
+//! | `clear`       | Drop all entries                     | O(n)       |
 //!
 //! ## Performance Trade-offs
-//! - Avoids cloning large keys by storing handles only.
-//! - Extra indirection requires a separate interner for key lookup.
-//! - Uses `Arc<V>` values; cloning is cheap but still allocates on insert.
+//!
+//! **Advantages:**
+//! - Avoids cloning large keys—stores only compact handles
+//! - `Arc<V>` enables cheap value sharing across policy and user code
+//! - Metrics tracking with minimal overhead (Cell/Atomic)
+//!
+//! **Costs:**
+//! - Requires separate `KeyInterner` for key ↔ handle mapping
+//! - `Arc<V>` allocation on every insert
+//! - Extra indirection compared to direct key storage
 //!
 //! ## When to Use
-//! - You already use a `KeyInterner` or stable handle IDs.
-//! - You want to minimize key cloning for large keys.
-//! - Policy metadata is keyed by handle rather than full keys.
+//!
+//! - You already use a [`KeyInterner`](crate::ds::KeyInterner) or stable handle IDs
+//! - Keys are large (strings, compound types) and cloning is expensive
+//! - Policy metadata is keyed by handle rather than full keys
+//! - You need `Arc<V>` semantics for value sharing
 //!
 //! ## Example Usage
+//!
 //! ```rust
 //! use std::sync::Arc;
-//!
 //! use cachekit::ds::KeyInterner;
 //! use cachekit::store::handle::HandleStore;
 //!
+//! // Create interner and store
 //! let mut interner = KeyInterner::new();
-//! let handle = interner.intern(&"alpha".to_string());
-//! let mut store: HandleStore<u64, String> = HandleStore::new(2);
-//! store.try_insert(handle, Arc::new("value".to_string())).unwrap();
-//! assert!(store.contains(&handle));
-//! assert_eq!(store.get(&handle), Some(Arc::new("value".to_string())));
-//! assert_eq!(store.remove(&handle), Some(Arc::new("value".to_string())));
-//! assert!(!store.contains(&handle));
+//! let mut store: HandleStore<u64, String> = HandleStore::new(100);
+//!
+//! // Intern a key to get a handle
+//! let handle = interner.intern(&"user:12345".to_string());
+//!
+//! // Store value by handle
+//! store.try_insert(handle, Arc::new("cached_data".to_string())).unwrap();
+//!
+//! // Retrieve by handle
+//! assert_eq!(store.get(&handle), Some(Arc::new("cached_data".to_string())));
+//!
+//! // Check metrics
+//! let metrics = store.metrics();
+//! assert_eq!(metrics.hits, 1);
+//! assert_eq!(metrics.inserts, 1);
 //! ```
 //!
 //! ## Type Constraints
-//! - `H: Copy + Eq + Hash` for handle lookup.
-//! - Values are stored as `Arc<V>`.
+//!
+//! - `H: Copy + Eq + Hash` — handles must be cheap to copy and hashable
+//! - Values stored as `Arc<V>` — enables shared ownership
+//! - For concurrent: `H: Send + Sync`, `V: Send + Sync`
 //!
 //! ## Thread Safety
-//! - `HandleStore` is single-threaded.
-//! - `ConcurrentHandleStore` is `Send + Sync` via `RwLock`.
+//!
+//! - [`HandleStore`] is **not** thread-safe (uses `Cell` for metrics)
+//! - [`ConcurrentHandleStore`] is `Send + Sync` via `parking_lot::RwLock`
 //!
 //! ## Implementation Notes
-//! - Handles must remain stable for the lifetime of stored entries.
-//! - Metrics are stored separately to keep the hot path simple.
-//! - Does NOT implement `StoreCore`/`StoreMut` traits (uses `Arc<V>` API).
+//!
+//! - Handles must remain stable for the lifetime of stored entries
+//! - Metrics are stored separately from the map to keep the hot path simple
+//! - Does **not** implement `StoreCore`/`StoreMut` (uses `Arc<V>` API instead)
+//! - `record_eviction()` is separate from `remove()` for policy-driven eviction tracking
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -72,14 +146,23 @@ use crate::store::traits::{
     ConcurrentStore, ConcurrentStoreFactory, ConcurrentStoreRead, StoreFull, StoreMetrics,
 };
 
-/// Store metrics counters for single-threaded handle stores.
+/// Metrics counters for single-threaded handle stores.
+///
+/// Uses `Cell<u64>` for interior mutability without synchronization overhead.
+/// Not thread-safe—intended for use with [`HandleStore`] only.
 #[derive(Debug, Default)]
 struct StoreCounters {
+    /// Successful lookups via `get()`.
     hits: Cell<u64>,
+    /// Failed lookups via `get()`.
     misses: Cell<u64>,
+    /// New key insertions.
     inserts: Cell<u64>,
+    /// Value updates for existing keys.
     updates: Cell<u64>,
+    /// Explicit removals via `remove()`.
     removes: Cell<u64>,
+    /// Policy-driven evictions via `record_eviction()`.
     evictions: Cell<u64>,
 }
 
@@ -120,14 +203,23 @@ impl StoreCounters {
     }
 }
 
-/// Store metrics counters for concurrent handle stores.
+/// Metrics counters for concurrent handle stores.
+///
+/// Uses `AtomicU64` with relaxed ordering for lock-free counter updates.
+/// Counters may be slightly stale in concurrent reads but are eventually consistent.
 #[derive(Debug, Default)]
 struct ConcurrentStoreCounters {
+    /// Successful lookups via `get()`.
     hits: AtomicU64,
+    /// Failed lookups via `get()`.
     misses: AtomicU64,
+    /// New key insertions.
     inserts: AtomicU64,
+    /// Value updates for existing keys.
     updates: AtomicU64,
+    /// Explicit removals via `remove()`.
     removes: AtomicU64,
+    /// Policy-driven evictions via `record_eviction()`.
     evictions: AtomicU64,
 }
 
@@ -172,9 +264,48 @@ impl ConcurrentStoreCounters {
 // Single-threaded HandleStore
 // =============================================================================
 
-/// Store keyed by compact handles (IDs) instead of full keys.
+/// Single-threaded store keyed by compact handles instead of full keys.
 ///
-/// Uses `Arc<V>` for value sharing with interner patterns.
+/// Designed for use with [`KeyInterner`](crate::ds::KeyInterner) where handles
+/// (typically `u64`) replace expensive-to-clone keys. Values are stored as
+/// `Arc<V>` to enable cheap sharing between the store and policy layers.
+///
+/// # Type Parameters
+///
+/// - `H`: Handle type, must be `Copy + Eq + Hash` (typically `u64` or `usize`)
+/// - `V`: Value type, wrapped in `Arc<V>` internally
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use cachekit::store::handle::HandleStore;
+///
+/// let mut store: HandleStore<u64, String> = HandleStore::new(3);
+///
+/// // Insert entries using handles (e.g., from an interner)
+/// let handle_a = 1u64;
+/// let handle_b = 2u64;
+///
+/// store.try_insert(handle_a, Arc::new("alice".into())).unwrap();
+/// store.try_insert(handle_b, Arc::new("bob".into())).unwrap();
+///
+/// // Lookup returns Arc<V>
+/// assert_eq!(store.get(&handle_a), Some(Arc::new("alice".into())));
+///
+/// // Peek without affecting metrics
+/// assert!(store.peek(&handle_b).is_some());
+///
+/// // Update existing entry
+/// let old = store.try_insert(handle_a, Arc::new("alice_v2".into())).unwrap();
+/// assert_eq!(old, Some(Arc::new("alice".into())));
+///
+/// // Check metrics
+/// let m = store.metrics();
+/// assert_eq!(m.inserts, 2);  // handle_a, handle_b
+/// assert_eq!(m.updates, 1);  // handle_a updated
+/// assert_eq!(m.hits, 1);     // one get() call
+/// ```
 #[derive(Debug)]
 pub struct HandleStore<H, V> {
     map: HashMap<H, Arc<V>>,
@@ -186,7 +317,17 @@ impl<H, V> HandleStore<H, V>
 where
     H: Copy + Eq + Hash,
 {
-    /// Create a handle store with a fixed capacity.
+    /// Creates a new handle store with the specified maximum capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let store: HandleStore<u64, i32> = HandleStore::new(1000);
+    /// assert_eq!(store.capacity(), 1000);
+    /// assert!(store.is_empty());
+    /// ```
     pub fn new(capacity: usize) -> Self {
         Self {
             map: HashMap::new(),
@@ -195,7 +336,26 @@ where
         }
     }
 
-    /// Fetch a value by handle.
+    /// Returns a clone of the value for the given handle.
+    ///
+    /// Updates hit/miss metrics. Use [`peek`](Self::peek) to avoid metric updates.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let mut store: HandleStore<u64, &str> = HandleStore::new(10);
+    /// store.try_insert(1, Arc::new("value")).unwrap();
+    ///
+    /// assert_eq!(store.get(&1), Some(Arc::new("value")));
+    /// assert_eq!(store.get(&999), None);  // miss
+    ///
+    /// let m = store.metrics();
+    /// assert_eq!(m.hits, 1);
+    /// assert_eq!(m.misses, 1);
+    /// ```
     pub fn get(&self, handle: &H) -> Option<Arc<V>> {
         match self.map.get(handle).cloned() {
             Some(value) => {
@@ -209,17 +369,62 @@ where
         }
     }
 
-    /// Fetch a value by handle without updating metrics.
+    /// Returns a reference to the value without updating metrics.
+    ///
+    /// Useful for internal operations that shouldn't affect hit/miss counts.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let mut store: HandleStore<u64, i32> = HandleStore::new(10);
+    /// store.try_insert(1, Arc::new(42)).unwrap();
+    ///
+    /// // Peek doesn't update metrics
+    /// assert_eq!(store.peek(&1), Some(&Arc::new(42)));
+    /// assert_eq!(store.metrics().hits, 0);
+    /// ```
     pub fn peek(&self, handle: &H) -> Option<&Arc<V>> {
         self.map.get(handle)
     }
 
-    /// Check whether a handle exists.
+    /// Returns `true` if the handle exists in the store.
+    ///
+    /// Does not update metrics.
     pub fn contains(&self, handle: &H) -> bool {
         self.map.contains_key(handle)
     }
 
-    /// Insert or update an entry.
+    /// Inserts or updates a value by handle.
+    ///
+    /// Returns `Ok(Some(old_value))` if the handle existed, `Ok(None)` for new
+    /// insertions. Updates the `inserts` or `updates` metric accordingly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if the store is at capacity and the handle is new.
+    /// Updates to existing handles always succeed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    /// use cachekit::store::traits::StoreFull;
+    ///
+    /// let mut store: HandleStore<u64, &str> = HandleStore::new(1);
+    ///
+    /// // First insert succeeds
+    /// assert_eq!(store.try_insert(1, Arc::new("a")), Ok(None));
+    ///
+    /// // Update existing handle succeeds even at capacity
+    /// assert_eq!(store.try_insert(1, Arc::new("b")), Ok(Some(Arc::new("a"))));
+    ///
+    /// // New handle fails when at capacity
+    /// assert_eq!(store.try_insert(2, Arc::new("c")), Err(StoreFull));
+    /// ```
     pub fn try_insert(&mut self, handle: H, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
         if !self.map.contains_key(&handle) && self.map.len() >= self.capacity {
             return Err(StoreFull);
@@ -233,7 +438,23 @@ where
         Ok(previous)
     }
 
-    /// Remove a value by handle.
+    /// Removes and returns the value for the given handle.
+    ///
+    /// Updates the `removes` metric if an entry was removed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let mut store: HandleStore<u64, &str> = HandleStore::new(10);
+    /// store.try_insert(1, Arc::new("value")).unwrap();
+    ///
+    /// assert_eq!(store.remove(&1), Some(Arc::new("value")));
+    /// assert_eq!(store.remove(&1), None);  // already removed
+    /// assert_eq!(store.metrics().removes, 1);
+    /// ```
     pub fn remove(&mut self, handle: &H) -> Option<Arc<V>> {
         let removed = self.map.remove(handle);
         if removed.is_some() {
@@ -242,32 +463,72 @@ where
         removed
     }
 
-    /// Clear all entries.
+    /// Removes all entries from the store.
+    ///
+    /// Does not update metrics. Capacity remains unchanged.
     pub fn clear(&mut self) {
         self.map.clear();
     }
 
-    /// Return the number of entries.
+    /// Returns the current number of entries.
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
-    /// Check if the store is empty.
+    /// Returns `true` if the store contains no entries.
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
-    /// Return the maximum capacity.
+    /// Returns the maximum number of entries this store can hold.
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
-    /// Snapshot store metrics.
+    /// Returns a snapshot of the store's metrics.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let mut store: HandleStore<u64, i32> = HandleStore::new(10);
+    /// store.try_insert(1, Arc::new(100)).unwrap();
+    /// store.get(&1);
+    /// store.get(&999);  // miss
+    ///
+    /// let m = store.metrics();
+    /// assert_eq!(m.inserts, 1);
+    /// assert_eq!(m.hits, 1);
+    /// assert_eq!(m.misses, 1);
+    /// ```
     pub fn metrics(&self) -> StoreMetrics {
         self.metrics.snapshot()
     }
 
-    /// Record an eviction.
+    /// Records an eviction in the metrics.
+    ///
+    /// Call this when the policy evicts an entry. Separate from [`remove`](Self::remove)
+    /// to distinguish user-initiated removals from policy-driven evictions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::HandleStore;
+    ///
+    /// let mut store: HandleStore<u64, i32> = HandleStore::new(10);
+    /// store.try_insert(1, Arc::new(100)).unwrap();
+    ///
+    /// // Policy decides to evict
+    /// store.remove(&1);
+    /// store.record_eviction();
+    ///
+    /// let m = store.metrics();
+    /// assert_eq!(m.removes, 1);
+    /// assert_eq!(m.evictions, 1);
+    /// ```
     pub fn record_eviction(&self) {
         self.metrics.inc_eviction();
     }
@@ -277,7 +538,61 @@ where
 // Concurrent HandleStore
 // =============================================================================
 
-/// Concurrent handle store using a `parking_lot::RwLock`.
+/// Thread-safe handle store using `parking_lot::RwLock`.
+///
+/// Provides the same functionality as [`HandleStore`] but safe for concurrent
+/// access from multiple threads. Implements [`ConcurrentStore`] and
+/// [`ConcurrentStoreFactory`] traits for integration with concurrent policies.
+///
+/// # Type Parameters
+///
+/// - `H`: Handle type, must be `Copy + Eq + Hash + Send + Sync`
+/// - `V`: Value type, must be `Send + Sync` (wrapped in `Arc<V>`)
+///
+/// # Synchronization
+///
+/// - Read operations (`get`, `contains`, `len`) acquire a read lock
+/// - Write operations (`try_insert`, `remove`, `clear`) acquire a write lock
+/// - Metrics use `AtomicU64` with relaxed ordering (lock-free)
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::store::handle::ConcurrentHandleStore;
+/// use cachekit::store::traits::ConcurrentStoreRead;
+///
+/// let store = Arc::new(ConcurrentHandleStore::<u64, String>::new(100));
+///
+/// // Spawn writers
+/// let store_w = Arc::clone(&store);
+/// let writer = thread::spawn(move || {
+///     use cachekit::store::traits::ConcurrentStore;
+///     for i in 0..10 {
+///         store_w.try_insert(i, Arc::new(format!("value_{}", i))).unwrap();
+///     }
+/// });
+///
+/// // Spawn readers
+/// let store_r = Arc::clone(&store);
+/// let reader = thread::spawn(move || {
+///     // Readers may see partial writes
+///     let _ = store_r.get(&5);
+///     store_r.len()
+/// });
+///
+/// writer.join().unwrap();
+/// reader.join().unwrap();
+///
+/// assert_eq!(store.len(), 10);
+/// ```
+///
+/// # Trait Implementations
+///
+/// - [`ConcurrentStoreRead<H, V>`] — read operations
+/// - [`ConcurrentStore<H, V>`] — write operations
+/// - [`ConcurrentStoreFactory<H, V>`] — factory for creating instances
 #[derive(Debug)]
 pub struct ConcurrentHandleStore<H, V> {
     map: RwLock<HashMap<H, Arc<V>>>,
@@ -289,7 +604,18 @@ impl<H, V> ConcurrentHandleStore<H, V>
 where
     H: Copy + Eq + Hash + Send + Sync,
 {
-    /// Create a concurrent handle store with a fixed capacity.
+    /// Creates a new concurrent handle store with the specified capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::handle::ConcurrentHandleStore;
+    /// use cachekit::store::traits::ConcurrentStoreRead;
+    ///
+    /// let store: ConcurrentHandleStore<u64, String> = ConcurrentHandleStore::new(1000);
+    /// assert_eq!(store.capacity(), 1000);
+    /// assert!(store.is_empty());
+    /// ```
     pub fn new(capacity: usize) -> Self {
         Self {
             map: RwLock::new(HashMap::new()),
@@ -298,17 +624,43 @@ where
         }
     }
 
-    /// Record an eviction.
+    /// Records an eviction in the metrics.
+    ///
+    /// Thread-safe via atomic increment. Call when the policy evicts an entry.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::store::handle::ConcurrentHandleStore;
+    /// use cachekit::store::traits::{ConcurrentStore, ConcurrentStoreRead};
+    ///
+    /// let store: ConcurrentHandleStore<u64, i32> = ConcurrentHandleStore::new(10);
+    /// store.try_insert(1, Arc::new(100)).unwrap();
+    ///
+    /// // Policy evicts the entry
+    /// store.remove(&1);
+    /// store.record_eviction();
+    ///
+    /// assert_eq!(store.metrics().evictions, 1);
+    /// ```
     pub fn record_eviction(&self) {
         self.metrics.inc_eviction();
     }
 }
 
+/// Read operations for [`ConcurrentHandleStore`].
+///
+/// All methods acquire a read lock on the internal map. Multiple readers
+/// can access the store concurrently.
 impl<H, V> ConcurrentStoreRead<H, V> for ConcurrentHandleStore<H, V>
 where
     H: Copy + Eq + Hash + Send + Sync,
     V: Send + Sync,
 {
+    /// Returns a clone of the value for the given handle.
+    ///
+    /// Acquires a read lock. Updates hit/miss metrics atomically.
     fn get(&self, key: &H) -> Option<Arc<V>> {
         match self.map.read().get(key).cloned() {
             Some(value) => {
@@ -322,28 +674,47 @@ where
         }
     }
 
+    /// Returns `true` if the handle exists.
+    ///
+    /// Acquires a read lock. Does not update metrics.
     fn contains(&self, key: &H) -> bool {
         self.map.read().contains_key(key)
     }
 
+    /// Returns the current number of entries.
+    ///
+    /// Acquires a read lock. Value may be stale by the time it's used.
     fn len(&self) -> usize {
         self.map.read().len()
     }
 
+    /// Returns the maximum capacity.
     fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns a snapshot of the store's metrics.
+    ///
+    /// Metrics are read atomically but may reflect a slightly inconsistent
+    /// view across different counters under high concurrency.
     fn metrics(&self) -> StoreMetrics {
         self.metrics.snapshot()
     }
 }
 
+/// Write operations for [`ConcurrentHandleStore`].
+///
+/// All methods acquire a write lock on the internal map. Writers have
+/// exclusive access—no concurrent readers or writers during the operation.
 impl<H, V> ConcurrentStore<H, V> for ConcurrentHandleStore<H, V>
 where
     H: Copy + Eq + Hash + Send + Sync,
     V: Send + Sync,
 {
+    /// Inserts or updates a value by handle.
+    ///
+    /// Acquires a write lock. Returns `Ok(Some(old))` for updates,
+    /// `Ok(None)` for new insertions, `Err(StoreFull)` if at capacity.
     fn try_insert(&self, key: H, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
         let mut map = self.map.write();
         if !map.contains_key(&key) && map.len() >= self.capacity {
@@ -358,6 +729,9 @@ where
         Ok(previous)
     }
 
+    /// Removes and returns the value for the given handle.
+    ///
+    /// Acquires a write lock. Updates `removes` metric if entry existed.
     fn remove(&self, key: &H) -> Option<Arc<V>> {
         let removed = self.map.write().remove(key);
         if removed.is_some() {
@@ -366,11 +740,34 @@ where
         removed
     }
 
+    /// Removes all entries.
+    ///
+    /// Acquires a write lock. Does not update metrics.
     fn clear(&self) {
         self.map.write().clear();
     }
 }
 
+/// Factory implementation for [`ConcurrentHandleStore`].
+///
+/// Enables generic construction in concurrent cache policies.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::handle::ConcurrentHandleStore;
+/// use cachekit::store::traits::{ConcurrentStoreFactory, ConcurrentStoreRead};
+///
+/// fn create_store<F, H, V>(capacity: usize) -> F::Store
+/// where
+///     F: ConcurrentStoreFactory<H, V>,
+/// {
+///     F::create(capacity)
+/// }
+///
+/// let store = create_store::<ConcurrentHandleStore<u64, String>, _, _>(100);
+/// assert_eq!(store.capacity(), 100);
+/// ```
 impl<H, V> ConcurrentStoreFactory<H, V> for ConcurrentHandleStore<H, V>
 where
     H: Copy + Eq + Hash + Send + Sync,

--- a/src/store/hashmap.rs
+++ b/src/store/hashmap.rs
@@ -1,53 +1,154 @@
 //! HashMap-backed store implementations.
 //!
+//! Provides three store variants optimized for different concurrency needs:
+//! single-threaded with zero-overhead access, global-lock concurrent, and
+//! sharded concurrent for high-contention workloads.
+//!
 //! ## Architecture
-//! - Single-threaded `HashMapStore` stores `V` directly (no `Arc` overhead).
-//! - Concurrent variants use `Arc<V>` for safe shared access across threads.
-//! - Capacity is enforced by entry count, not byte size.
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                        HashMap Store Variants                               │
+//! │                                                                             │
+//! │  ┌─────────────────────────────────────────────────────────────────────┐   │
+//! │  │                     HashMapStore (single-threaded)                   │   │
+//! │  │                                                                      │   │
+//! │  │   ┌──────────────┐      get(&K) -> &V                               │   │
+//! │  │   │ HashMap<K,V> │      (zero-copy, no Arc)                         │   │
+//! │  │   └──────────────┘                                                   │   │
+//! │  │         │                                                            │   │
+//! │  │         └── Direct ownership, best for single-threaded hot paths    │   │
+//! │  └─────────────────────────────────────────────────────────────────────┘   │
+//! │                                                                             │
+//! │  ┌─────────────────────────────────────────────────────────────────────┐   │
+//! │  │                 ConcurrentHashMapStore (global lock)                 │   │
+//! │  │                                                                      │   │
+//! │  │   ┌─────────────────────────┐     get(&K) -> Arc<V>                 │   │
+//! │  │   │ RwLock<HashMap<K,Arc<V>>│     (clone Arc, releases lock)        │   │
+//! │  │   └─────────────────────────┘                                        │   │
+//! │  │         │                                                            │   │
+//! │  │         └── Simple concurrency, moderate contention OK              │   │
+//! │  └─────────────────────────────────────────────────────────────────────┘   │
+//! │                                                                             │
+//! │  ┌─────────────────────────────────────────────────────────────────────┐   │
+//! │  │                  ShardedHashMapStore (per-shard locks)               │   │
+//! │  │                                                                      │   │
+//! │  │   key ──► hash(key) % N ──► shard[i]                                │   │
+//! │  │                                                                      │   │
+//! │  │   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐                       │   │
+//! │  │   │Shard 0 │ │Shard 1 │ │Shard 2 │ │Shard N │                       │   │
+//! │  │   │RwLock  │ │RwLock  │ │RwLock  │ │RwLock  │                       │   │
+//! │  │   │HashMap │ │HashMap │ │HashMap │ │HashMap │                       │   │
+//! │  │   └────────┘ └────────┘ └────────┘ └────────┘                       │   │
+//! │  │         │                                                            │   │
+//! │  │         └── High concurrency, independent shard access              │   │
+//! │  └─────────────────────────────────────────────────────────────────────┘   │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!
+//! Trait Implementations
+//! ─────────────────────
+//!
+//!   HashMapStore<K, V, S>
+//!     ├── StoreCore<K, V>      read ops, returns &V
+//!     ├── StoreMut<K, V>       write ops, owned V
+//!     └── StoreFactory<K, V>   factory (default hasher only)
+//!
+//!   ConcurrentHashMapStore<K, V, S>
+//!     ├── ConcurrentStoreRead<K, V>     read ops, returns Arc<V>
+//!     ├── ConcurrentStore<K, V>         write ops, Arc<V>
+//!     └── ConcurrentStoreFactory<K, V>  factory (default hasher only)
+//!
+//!   ShardedHashMapStore<K, V, S>
+//!     ├── ConcurrentStoreRead<K, V>     read ops, returns Arc<V>
+//!     ├── ConcurrentStore<K, V>         write ops, Arc<V>
+//!     └── ConcurrentStoreFactory<K, V>  factory (auto-detects shard count)
+//!
+//! Concurrency Comparison
+//! ──────────────────────
+//!
+//!   │ Store                   │ Lock Scope │ Contention │ Use Case            │
+//!   │─────────────────────────│────────────│────────────│─────────────────────│
+//!   │ HashMapStore            │ None       │ N/A        │ Single-threaded     │
+//!   │ ConcurrentHashMapStore  │ Global     │ Moderate   │ Simple concurrency  │
+//!   │ ShardedHashMapStore     │ Per-shard  │ Low        │ High parallelism    │
+//! ```
 //!
 //! ## Key Components
-//! - `HashMapStore`: single-threaded store with zero-overhead value access.
-//! - `ConcurrentHashMapStore`: thread-safe store with a global `RwLock`.
-//! - `ShardedHashMapStore`: thread-safe store with per-shard locks.
+//!
+//! - [`HashMapStore`]: Single-threaded store with zero-overhead `&V` access
+//! - [`ConcurrentHashMapStore`]: Thread-safe store with global `RwLock`
+//! - [`ShardedHashMapStore`]: Thread-safe store with per-shard locks
 //!
 //! ## Core Operations
-//! - `try_insert`: insert or update by key.
-//! - `get`: fetch by key (updates hit/miss metrics).
-//! - `remove`: delete by key.
-//! - `clear`: drop all entries.
+//!
+//! | Operation     | Single-threaded      | Concurrent           |
+//! |---------------|----------------------|----------------------|
+//! | `get`         | `&V` (zero-copy)     | `Arc<V>` (cloned)    |
+//! | `try_insert`  | `V` owned            | `Arc<V>` owned       |
+//! | `remove`      | `Option<V>`          | `Option<Arc<V>>`     |
+//! | `peek`        | `&V` (no metrics)    | N/A                  |
 //!
 //! ## Performance Trade-offs
-//! - Single-threaded: returns `&V` references, no allocation on access.
-//! - Concurrent: returns `Arc<V>`, requires atomic ref-count increment.
-//! - Sharding reduces contention at the cost of extra hashing.
+//!
+//! **Single-threaded (`HashMapStore`):**
+//! - Returns `&V` references—no allocation on access
+//! - Fastest option when concurrency isn't needed
+//! - Custom hasher support for specialized workloads
+//!
+//! **Global lock (`ConcurrentHashMapStore`):**
+//! - Simple implementation, predictable behavior
+//! - All operations serialize on the same lock
+//! - Good for low-to-moderate concurrency
+//!
+//! **Sharded (`ShardedHashMapStore`):**
+//! - Keys distributed across N independent shards
+//! - Operations on different shards run in parallel
+//! - Extra hashing cost to select shard
+//! - Atomic size counter for global `len()`
 //!
 //! ## When to Use
-//! - `HashMapStore`: single-threaded hot paths where allocation matters.
-//! - `ConcurrentHashMapStore`: simple thread-safe caching.
-//! - `ShardedHashMapStore`: high-contention concurrent workloads.
+//!
+//! - [`HashMapStore`]: Single-threaded hot paths, no allocation on access
+//! - [`ConcurrentHashMapStore`]: Simple thread-safe caching, moderate load
+//! - [`ShardedHashMapStore`]: High-contention concurrent workloads
 //!
 //! ## Example Usage
+//!
 //! ```rust
 //! use cachekit::store::hashmap::HashMapStore;
-//! use cachekit::store::traits::StoreMut;
-//! use cachekit::store::traits::StoreCore;
+//! use cachekit::store::traits::{StoreCore, StoreMut};
 //!
-//! let mut store: HashMapStore<u64, String> = HashMapStore::new(2);
-//! store.try_insert(1, "hello".to_string()).unwrap();
-//! assert_eq!(store.get(&1), Some(&"hello".to_string()));
+//! let mut store: HashMapStore<&str, i32> = HashMapStore::new(100);
+//!
+//! // Insert and access
+//! store.try_insert("key", 42).unwrap();
+//! assert_eq!(store.get(&"key"), Some(&42));  // Returns &V, zero-copy
+//!
+//! // Peek without metrics
+//! assert_eq!(store.peek(&"key"), Some(&42));
+//!
+//! // Check metrics
+//! let m = store.metrics();
+//! assert_eq!(m.hits, 1);  // get() counted
+//! assert_eq!(m.inserts, 1);
 //! ```
 //!
 //! ## Type Constraints
-//! - `K: Eq + Hash` for key lookup.
-//! - `S: BuildHasher` for custom hashers (defaults to `RandomState`).
+//!
+//! - `K: Eq + Hash` — keys must be hashable and comparable
+//! - `S: BuildHasher` — custom hasher support (defaults to `RandomState`)
+//! - Concurrent variants require `K: Send + Sync`, `V: Send + Sync`
 //!
 //! ## Thread Safety
-//! - `HashMapStore` is single-threaded.
-//! - `ConcurrentHashMapStore` and `ShardedHashMapStore` are `Send + Sync`.
+//!
+//! - [`HashMapStore`] is **not** thread-safe (single-threaded only)
+//! - [`ConcurrentHashMapStore`] and [`ShardedHashMapStore`] are `Send + Sync`
 //!
 //! ## Implementation Notes
-//! - Sharded store uses the configured hasher to pick shards.
-//! - Metrics are tracked with atomics for concurrent access.
+//!
+//! - Sharded store uses `hash(key) % shard_count` for shard selection
+//! - Metrics use `AtomicU64` with relaxed ordering (lock-free)
+//! - Factory implementations use default hasher; use `with_hasher` for custom
 
 use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
@@ -66,14 +167,24 @@ use crate::store::traits::{
 // Metrics counters
 // =============================================================================
 
-/// Store metrics counters using atomics for thread-safe updates.
+/// Metrics counters using atomics for thread-safe updates.
+///
+/// All counters use `Ordering::Relaxed` for low-overhead increments.
+/// Snapshot reads may reflect a slightly inconsistent view across counters
+/// under high concurrency, but individual counters are always accurate.
 #[derive(Debug, Default)]
 struct StoreCounters {
+    /// Successful lookups via `get()`.
     hits: AtomicU64,
+    /// Failed lookups via `get()`.
     misses: AtomicU64,
+    /// New key insertions.
     inserts: AtomicU64,
+    /// Value updates for existing keys.
     updates: AtomicU64,
+    /// Explicit removals via `remove()`.
     removes: AtomicU64,
+    /// Policy-driven evictions via `record_eviction()`.
     evictions: AtomicU64,
 }
 
@@ -118,9 +229,56 @@ impl StoreCounters {
 // Single-threaded HashMapStore
 // =============================================================================
 
-/// Single-threaded HashMap-backed store.
+/// Single-threaded HashMap-backed store with zero-overhead value access.
 ///
-/// Stores values directly without `Arc` wrapper for zero-overhead access.
+/// Stores values directly (not wrapped in `Arc`) so `get()` returns `&V`
+/// without allocation. Implements [`StoreCore`] and [`StoreMut`] traits
+/// for integration with single-threaded cache policies.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Eq + Hash`
+/// - `V`: Value type, stored directly (owned)
+/// - `S`: Hasher type, defaults to `RandomState`
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::hashmap::HashMapStore;
+/// use cachekit::store::traits::{StoreCore, StoreMut};
+///
+/// let mut store: HashMapStore<String, Vec<u8>> = HashMapStore::new(1000);
+///
+/// // Insert data
+/// store.try_insert("image.png".into(), vec![0x89, 0x50, 0x4E, 0x47]).unwrap();
+///
+/// // Access returns &V (zero-copy)
+/// let data: &Vec<u8> = store.get(&"image.png".into()).unwrap();
+/// assert_eq!(data[0], 0x89);
+///
+/// // Mutable access for in-place updates
+/// if let Some(data) = store.peek_mut(&"image.png".into()) {
+///     data.push(0x0D);
+/// }
+///
+/// // Metrics tracking
+/// let m = store.metrics();
+/// assert_eq!(m.hits, 1);
+/// assert_eq!(m.inserts, 1);
+/// ```
+///
+/// # Custom Hasher
+///
+/// ```ignore
+/// use std::hash::BuildHasherDefault;
+/// use rustc_hash::FxHasher;  // Add rustc-hash to Cargo.toml
+/// use cachekit::store::hashmap::HashMapStore;
+///
+/// type FxBuildHasher = BuildHasherDefault<FxHasher>;
+///
+/// let store: HashMapStore<u64, String, FxBuildHasher> =
+///     HashMapStore::with_hasher(100, FxBuildHasher::default());
+/// ```
 #[derive(Debug)]
 pub struct HashMapStore<K, V, S = RandomState> {
     map: HashMap<K, V, S>,
@@ -132,7 +290,18 @@ impl<K, V> HashMapStore<K, V, RandomState>
 where
     K: Eq + Hash,
 {
-    /// Create a store with a fixed capacity and default hasher.
+    /// Creates a store with the specified capacity using the default hasher.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::HashMapStore;
+    /// use cachekit::store::traits::StoreCore;
+    ///
+    /// let store: HashMapStore<i32, String> = HashMapStore::new(100);
+    /// assert_eq!(store.capacity(), 100);
+    /// assert!(store.is_empty());
+    /// ```
     pub fn new(capacity: usize) -> Self {
         Self::with_hasher(capacity, RandomState::new())
     }
@@ -143,7 +312,23 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    /// Create a store with a fixed capacity and custom hasher.
+    /// Creates a store with the specified capacity and custom hasher.
+    ///
+    /// Use this when you need a deterministic or faster hasher than the
+    /// default `RandomState`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::hash_map::RandomState;
+    /// use cachekit::store::hashmap::HashMapStore;
+    /// use cachekit::store::traits::StoreCore;
+    ///
+    /// // Use explicit RandomState (or any BuildHasher impl)
+    /// let store: HashMapStore<&str, i32, RandomState> =
+    ///     HashMapStore::with_hasher(50, RandomState::new());
+    /// assert_eq!(store.capacity(), 50);
+    /// ```
     pub fn with_hasher(capacity: usize, hasher: S) -> Self {
         Self {
             map: HashMap::with_capacity_and_hasher(capacity, hasher),
@@ -152,32 +337,97 @@ where
         }
     }
 
-    /// Fetch a value by key without touching metrics.
+    /// Returns a reference to the value without updating metrics.
+    ///
+    /// Useful for internal operations that shouldn't affect hit/miss counts.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::HashMapStore;
+    /// use cachekit::store::traits::{StoreCore, StoreMut};
+    ///
+    /// let mut store: HashMapStore<&str, i32> = HashMapStore::new(10);
+    /// store.try_insert("key", 42).unwrap();
+    ///
+    /// // Peek doesn't update metrics
+    /// assert_eq!(store.peek(&"key"), Some(&42));
+    /// assert_eq!(store.metrics().hits, 0);
+    /// ```
     pub fn peek(&self, key: &K) -> Option<&V> {
         self.map.get(key)
     }
 
-    /// Fetch a mutable reference to a value without touching metrics.
+    /// Returns a mutable reference to the value without updating metrics.
+    ///
+    /// Allows in-place modification of stored values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::HashMapStore;
+    /// use cachekit::store::traits::StoreMut;
+    ///
+    /// let mut store: HashMapStore<&str, Vec<i32>> = HashMapStore::new(10);
+    /// store.try_insert("nums", vec![1, 2, 3]).unwrap();
+    ///
+    /// // Modify in place
+    /// if let Some(nums) = store.peek_mut(&"nums") {
+    ///     nums.push(4);
+    /// }
+    ///
+    /// assert_eq!(store.peek(&"nums"), Some(&vec![1, 2, 3, 4]));
+    /// ```
     pub fn peek_mut(&mut self, key: &K) -> Option<&mut V> {
         self.map.get_mut(key)
     }
 
-    /// Return the backing hash map capacity.
+    /// Returns the underlying HashMap's allocated capacity.
+    ///
+    /// This may be larger than the logical capacity limit set at creation.
     pub fn map_capacity(&self) -> usize {
         self.map.capacity()
     }
 
-    /// Record that the policy evicted an entry.
+    /// Records an eviction in the metrics.
+    ///
+    /// Call when the policy evicts an entry. Separate from `remove()` to
+    /// distinguish user-initiated removals from policy-driven evictions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::HashMapStore;
+    /// use cachekit::store::traits::{StoreCore, StoreMut};
+    ///
+    /// let mut store: HashMapStore<&str, i32> = HashMapStore::new(10);
+    /// store.try_insert("key", 1).unwrap();
+    ///
+    /// // Policy evicts the entry
+    /// store.remove(&"key");
+    /// store.record_eviction();
+    ///
+    /// let m = store.metrics();
+    /// assert_eq!(m.removes, 1);
+    /// assert_eq!(m.evictions, 1);
+    /// ```
     pub fn record_eviction(&self) {
         self.metrics.inc_eviction();
     }
 }
 
+/// Read operations for [`HashMapStore`].
+///
+/// Returns borrowed `&V` references for zero-copy access.
 impl<K, V, S> StoreCore<K, V> for HashMapStore<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
+    /// Returns a reference to the value for the given key.
+    ///
+    /// Updates hit/miss metrics. Use [`peek`](HashMapStore::peek) to avoid
+    /// metric updates.
     fn get(&self, key: &K) -> Option<&V> {
         match self.map.get(key) {
             Some(value) => {
@@ -191,28 +441,42 @@ where
         }
     }
 
+    /// Returns `true` if the key exists. Does not update metrics.
     fn contains(&self, key: &K) -> bool {
         self.map.contains_key(key)
     }
 
+    /// Returns the current number of entries.
     fn len(&self) -> usize {
         self.map.len()
     }
 
+    /// Returns the logical capacity limit.
     fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns a snapshot of the store's metrics.
     fn metrics(&self) -> StoreMetrics {
         self.metrics.snapshot()
     }
 }
 
+/// Write operations for [`HashMapStore`].
+///
+/// Takes and returns owned `V` values directly.
 impl<K, V, S> StoreMut<K, V> for HashMapStore<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
+    /// Inserts or updates a value.
+    ///
+    /// Returns `Ok(Some(old))` for updates, `Ok(None)` for new insertions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if at capacity and the key is new.
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreFull> {
         if !self.map.contains_key(&key) && self.map.len() >= self.capacity {
             return Err(StoreFull);
@@ -226,6 +490,9 @@ where
         Ok(previous)
     }
 
+    /// Removes and returns the value for the given key.
+    ///
+    /// Updates `removes` metric if an entry was removed.
     fn remove(&mut self, key: &K) -> Option<V> {
         let removed = self.map.remove(key);
         if removed.is_some() {
@@ -234,11 +501,27 @@ where
         removed
     }
 
+    /// Removes all entries. Does not update metrics.
     fn clear(&mut self) {
         self.map.clear();
     }
 }
 
+/// Factory for creating [`HashMapStore`] instances with default hasher.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::hashmap::HashMapStore;
+/// use cachekit::store::traits::{StoreFactory, StoreCore};
+///
+/// fn create_store<F: StoreFactory<String, i32>>(cap: usize) -> F::Store {
+///     F::create(cap)
+/// }
+///
+/// let store = create_store::<HashMapStore<String, i32>>(100);
+/// assert_eq!(store.capacity(), 100);
+/// ```
 impl<K, V> StoreFactory<K, V> for HashMapStore<K, V, RandomState>
 where
     K: Eq + Hash,
@@ -254,9 +537,51 @@ where
 // Concurrent HashMap store (global lock)
 // =============================================================================
 
-/// Concurrent HashMap-backed store using interior mutability.
+/// Thread-safe HashMap store with a single global `RwLock`.
 ///
-/// Uses `Arc<V>` for values since references can't outlive lock guards.
+/// Uses `Arc<V>` for values since borrowed references cannot outlive lock
+/// guards. Simple concurrency model—all operations serialize on the same
+/// lock. For high-contention workloads, consider [`ShardedHashMapStore`].
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Eq + Hash + Send + Sync`
+/// - `V`: Value type, must be `Send + Sync` (wrapped in `Arc<V>`)
+/// - `S`: Hasher type, must be `Send + Sync`, defaults to `RandomState`
+///
+/// # Synchronization
+///
+/// - Read operations (`get`, `contains`, `len`) acquire a read lock
+/// - Write operations (`try_insert`, `remove`, `clear`) acquire a write lock
+/// - Metrics use atomic counters (lock-free)
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::store::hashmap::ConcurrentHashMapStore;
+/// use cachekit::store::traits::{ConcurrentStore, ConcurrentStoreRead};
+///
+/// let store = Arc::new(ConcurrentHashMapStore::<String, i32>::new(100));
+///
+/// // Spawn multiple writers
+/// let handles: Vec<_> = (0..4).map(|t| {
+///     let store = Arc::clone(&store);
+///     thread::spawn(move || {
+///         for i in 0..25 {
+///             let key = format!("key_{}_{}", t, i);
+///             store.try_insert(key, Arc::new(i)).unwrap();
+///         }
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert_eq!(store.len(), 100);
+/// ```
 #[derive(Debug)]
 pub struct ConcurrentHashMapStore<K, V, S = RandomState> {
     map: RwLock<HashMap<K, Arc<V>, S>>,
@@ -268,7 +593,18 @@ impl<K, V> ConcurrentHashMapStore<K, V, RandomState>
 where
     K: Eq + Hash + Send,
 {
-    /// Create a concurrent store with default hasher.
+    /// Creates a concurrent store with the specified capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::ConcurrentHashMapStore;
+    /// use cachekit::store::traits::ConcurrentStoreRead;
+    ///
+    /// let store: ConcurrentHashMapStore<String, Vec<u8>> =
+    ///     ConcurrentHashMapStore::new(1000);
+    /// assert_eq!(store.capacity(), 1000);
+    /// ```
     pub fn new(capacity: usize) -> Self {
         Self::with_hasher(capacity, RandomState::new())
     }
@@ -279,7 +615,20 @@ where
     K: Eq + Hash + Send,
     S: BuildHasher,
 {
-    /// Create a concurrent store with a custom hasher.
+    /// Creates a concurrent store with the specified capacity and custom hasher.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::hash_map::RandomState;
+    /// use cachekit::store::hashmap::ConcurrentHashMapStore;
+    /// use cachekit::store::traits::ConcurrentStoreRead;
+    ///
+    /// // Use explicit RandomState (or any BuildHasher impl)
+    /// let store: ConcurrentHashMapStore<u64, String, RandomState> =
+    ///     ConcurrentHashMapStore::with_hasher(100, RandomState::new());
+    /// assert_eq!(store.capacity(), 100);
+    /// ```
     pub fn with_hasher(capacity: usize, hasher: S) -> Self {
         Self {
             map: RwLock::new(HashMap::with_capacity_and_hasher(capacity, hasher)),
@@ -288,18 +637,27 @@ where
         }
     }
 
-    /// Record that the policy evicted an entry.
+    /// Records an eviction in the metrics.
+    ///
+    /// Thread-safe via atomic increment.
     pub fn record_eviction(&self) {
         self.metrics.inc_eviction();
     }
 }
 
+/// Read operations for [`ConcurrentHashMapStore`].
+///
+/// All methods acquire a read lock. Multiple readers can access concurrently.
 impl<K, V, S> ConcurrentStoreRead<K, V> for ConcurrentHashMapStore<K, V, S>
 where
     K: Eq + Hash + Send + Sync,
     V: Send + Sync,
     S: BuildHasher + Send + Sync,
 {
+    /// Returns a clone of the value for the given key.
+    ///
+    /// Acquires read lock, clones `Arc<V>`, releases lock. The returned
+    /// `Arc` can be held indefinitely without blocking other operations.
     fn get(&self, key: &K) -> Option<Arc<V>> {
         match self.map.read().get(key).cloned() {
             Some(value) => {
@@ -313,29 +671,45 @@ where
         }
     }
 
+    /// Returns `true` if the key exists. Acquires read lock.
     fn contains(&self, key: &K) -> bool {
         self.map.read().contains_key(key)
     }
 
+    /// Returns the current number of entries.
+    ///
+    /// Acquires read lock. Value may be stale by the time it's used.
     fn len(&self) -> usize {
         self.map.read().len()
     }
 
+    /// Returns the logical capacity limit.
     fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns a snapshot of the store's metrics.
     fn metrics(&self) -> StoreMetrics {
         self.metrics.snapshot()
     }
 }
 
+/// Write operations for [`ConcurrentHashMapStore`].
+///
+/// All methods acquire a write lock. Writers have exclusive access.
 impl<K, V, S> ConcurrentStore<K, V> for ConcurrentHashMapStore<K, V, S>
 where
     K: Eq + Hash + Send + Sync,
     V: Send + Sync,
     S: BuildHasher + Send + Sync,
 {
+    /// Inserts or updates a value.
+    ///
+    /// Acquires write lock for the duration of the operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if at capacity and the key is new.
     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
         let mut map = self.map.write();
         if !map.contains_key(&key) && map.len() >= self.capacity {
@@ -350,6 +724,9 @@ where
         Ok(previous)
     }
 
+    /// Removes and returns the value for the given key.
+    ///
+    /// Acquires write lock.
     fn remove(&self, key: &K) -> Option<Arc<V>> {
         let removed = self.map.write().remove(key);
         if removed.is_some() {
@@ -358,11 +735,27 @@ where
         removed
     }
 
+    /// Removes all entries. Acquires write lock.
     fn clear(&self) {
         self.map.write().clear()
     }
 }
 
+/// Factory for creating [`ConcurrentHashMapStore`] instances.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::hashmap::ConcurrentHashMapStore;
+/// use cachekit::store::traits::{ConcurrentStoreFactory, ConcurrentStoreRead};
+///
+/// fn create<F: ConcurrentStoreFactory<String, i32>>(cap: usize) -> F::Store {
+///     F::create(cap)
+/// }
+///
+/// let store = create::<ConcurrentHashMapStore<String, i32>>(50);
+/// assert_eq!(store.capacity(), 50);
+/// ```
 impl<K, V> ConcurrentStoreFactory<K, V> for ConcurrentHashMapStore<K, V, RandomState>
 where
     K: Eq + Hash + Send + Sync,
@@ -379,9 +772,64 @@ where
 // Sharded HashMap store
 // =============================================================================
 
-/// Concurrent HashMap-backed store with sharded locking.
+/// Thread-safe HashMap store with per-shard locking for high concurrency.
 ///
-/// Reduces contention by distributing keys across multiple independent shards.
+/// Distributes keys across N independent shards, each with its own `RwLock`.
+/// Operations on different shards can proceed in parallel, reducing contention
+/// compared to [`ConcurrentHashMapStore`].
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, must be `Eq + Hash + Send + Sync`
+/// - `V`: Value type, must be `Send + Sync` (wrapped in `Arc<V>`)
+/// - `S`: Hasher type, must be `Clone + Send + Sync`, defaults to `RandomState`
+///
+/// # Shard Selection
+///
+/// Keys are assigned to shards via `hash(key) % shard_count`. The same hasher
+/// is used for both shard selection and within-shard HashMap operations.
+///
+/// # Capacity Enforcement
+///
+/// Global capacity is enforced via an `AtomicUsize` counter. The counter is
+/// updated with compare-and-swap on insert to prevent over-capacity races.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use cachekit::store::hashmap::ShardedHashMapStore;
+/// use cachekit::store::traits::{ConcurrentStore, ConcurrentStoreRead};
+///
+/// // Create store with 8 shards for 8-core machine
+/// let store = Arc::new(ShardedHashMapStore::<u64, String>::new(10000, 8));
+///
+/// // Spawn workers that operate on different key ranges (likely different shards)
+/// let handles: Vec<_> = (0..8).map(|t| {
+///     let store = Arc::clone(&store);
+///     thread::spawn(move || {
+///         let base = t * 1000;
+///         for i in 0..1000 {
+///             store.try_insert(base + i, Arc::new(format!("v{}", base + i))).unwrap();
+///         }
+///     })
+/// }).collect();
+///
+/// for h in handles {
+///     h.join().unwrap();
+/// }
+///
+/// assert_eq!(store.len(), 8000);
+/// assert_eq!(store.shard_count(), 8);
+/// ```
+///
+/// # Performance Considerations
+///
+/// - More shards = less contention but more memory overhead
+/// - Optimal shard count is typically 2-4x the number of CPU cores
+/// - Keys that hash to the same shard still contend
+/// - Use [`ConcurrentStoreFactory`] to auto-detect shard count
 #[derive(Debug)]
 pub struct ShardedHashMapStore<K, V, S = RandomState> {
     shards: Vec<RwLock<HashMap<K, Arc<V>, S>>>,
@@ -395,7 +843,24 @@ impl<K, V> ShardedHashMapStore<K, V, RandomState>
 where
     K: Eq + Hash + Send + Sync,
 {
-    /// Create a sharded store with the default hasher.
+    /// Creates a sharded store with the specified capacity and shard count.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - Maximum number of entries across all shards
+    /// * `shards` - Number of independent shards (minimum 1)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::ShardedHashMapStore;
+    /// use cachekit::store::traits::ConcurrentStoreRead;
+    ///
+    /// let store: ShardedHashMapStore<String, Vec<u8>> =
+    ///     ShardedHashMapStore::new(10000, 16);
+    /// assert_eq!(store.capacity(), 10000);
+    /// assert_eq!(store.shard_count(), 16);
+    /// ```
     pub fn new(capacity: usize, shards: usize) -> Self {
         Self::with_hasher(capacity, shards, RandomState::new())
     }
@@ -406,7 +871,21 @@ where
     K: Eq + Hash + Send + Sync,
     S: BuildHasher + Clone,
 {
-    /// Create a sharded store with a custom hasher.
+    /// Creates a sharded store with custom hasher.
+    ///
+    /// The hasher is cloned for each shard's internal HashMap.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::hash_map::RandomState;
+    /// use cachekit::store::hashmap::ShardedHashMapStore;
+    ///
+    /// // Use explicit RandomState (or any Clone + BuildHasher impl)
+    /// let store: ShardedHashMapStore<u64, String, RandomState> =
+    ///     ShardedHashMapStore::with_hasher(1000, 4, RandomState::new());
+    /// assert_eq!(store.shard_count(), 4);
+    /// ```
     pub fn with_hasher(capacity: usize, shards: usize, hasher: S) -> Self {
         let shard_count = shards.max(1);
         let mut shard_vec = Vec::with_capacity(shard_count);
@@ -422,28 +901,45 @@ where
         }
     }
 
-    /// Return the number of shards.
+    /// Returns the number of shards.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::store::hashmap::ShardedHashMapStore;
+    ///
+    /// let store: ShardedHashMapStore<u64, i32> = ShardedHashMapStore::new(100, 8);
+    /// assert_eq!(store.shard_count(), 8);
+    /// ```
     pub fn shard_count(&self) -> usize {
         self.shards.len()
     }
 
-    /// Compute the shard index for a key.
+    /// Computes the shard index for a key.
     fn shard_index(&self, key: &K) -> usize {
         (self.hasher.hash_one(key) as usize) % self.shards.len()
     }
 
-    /// Record that the policy evicted an entry.
+    /// Records an eviction in the metrics.
+    ///
+    /// Thread-safe via atomic increment.
     pub fn record_eviction(&self) {
         self.metrics.inc_eviction();
     }
 }
 
+/// Read operations for [`ShardedHashMapStore`].
+///
+/// Each operation only locks the shard containing the target key.
 impl<K, V, S> ConcurrentStoreRead<K, V> for ShardedHashMapStore<K, V, S>
 where
     K: Eq + Hash + Send + Sync,
     V: Send + Sync,
     S: BuildHasher + Clone + Send + Sync,
 {
+    /// Returns a clone of the value for the given key.
+    ///
+    /// Only locks the shard containing the key. Other shards remain accessible.
     fn get(&self, key: &K) -> Option<Arc<V>> {
         let idx = self.shard_index(key);
         match self.shards[idx].read().get(key).cloned() {
@@ -458,30 +954,49 @@ where
         }
     }
 
+    /// Returns `true` if the key exists. Only locks the target shard.
     fn contains(&self, key: &K) -> bool {
         let idx = self.shard_index(key);
         self.shards[idx].read().contains_key(key)
     }
 
+    /// Returns the current number of entries across all shards.
+    ///
+    /// Uses atomic load—no locking required. Value may be stale under
+    /// concurrent modifications.
     fn len(&self) -> usize {
         self.size.load(Ordering::Relaxed)
     }
 
+    /// Returns the global capacity limit.
     fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns a snapshot of the store's metrics.
     fn metrics(&self) -> StoreMetrics {
         self.metrics.snapshot()
     }
 }
 
+/// Write operations for [`ShardedHashMapStore`].
+///
+/// Each operation only locks the shard containing the target key, except
+/// `clear()` which locks all shards.
 impl<K, V, S> ConcurrentStore<K, V> for ShardedHashMapStore<K, V, S>
 where
     K: Eq + Hash + Send + Sync,
     V: Send + Sync,
     S: BuildHasher + Clone + Send + Sync,
 {
+    /// Inserts or updates a value.
+    ///
+    /// Only locks the target shard. Uses compare-and-swap on the global
+    /// size counter to enforce capacity without locking all shards.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if at capacity and the key is new.
     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
         let idx = self.shard_index(&key);
         let mut map = self.shards[idx].write();
@@ -496,6 +1011,7 @@ where
                     return Err(StoreFull);
                 }
 
+                // CAS loop to atomically reserve a slot
                 loop {
                     let current = self.size.load(Ordering::Relaxed);
                     if current >= self.capacity {
@@ -517,6 +1033,9 @@ where
         }
     }
 
+    /// Removes and returns the value for the given key.
+    ///
+    /// Only locks the target shard. Atomically decrements size counter.
     fn remove(&self, key: &K) -> Option<Arc<V>> {
         let idx = self.shard_index(key);
         let removed = self.shards[idx].write().remove(key);
@@ -527,7 +1046,12 @@ where
         removed
     }
 
+    /// Removes all entries from all shards.
+    ///
+    /// Acquires write locks on all shards simultaneously to ensure
+    /// consistency. This is the only operation that locks multiple shards.
     fn clear(&self) {
+        // Lock all shards first to prevent concurrent modifications
         let mut guards = Vec::with_capacity(self.shards.len());
         for shard in &self.shards {
             guards.push(shard.write());
@@ -539,6 +1063,22 @@ where
     }
 }
 
+/// Factory for creating [`ShardedHashMapStore`] instances.
+///
+/// Automatically detects the number of available CPU cores and creates
+/// that many shards for optimal parallelism.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::hashmap::ShardedHashMapStore;
+/// use cachekit::store::traits::{ConcurrentStoreFactory, ConcurrentStoreRead};
+///
+/// // Factory auto-detects optimal shard count
+/// let store = <ShardedHashMapStore<String, i32>>::create(10000);
+/// assert_eq!(store.capacity(), 10000);
+/// // shard_count() == number of CPU cores (or 1 if detection fails)
+/// ```
 impl<K, V> ConcurrentStoreFactory<K, V> for ShardedHashMapStore<K, V, RandomState>
 where
     K: Eq + Hash + Send + Sync,

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -4,6 +4,68 @@
 //! manage eviction order and metadata. This keeps policy logic independent
 //! of how values are stored (e.g., HashMap, concurrent map, arena).
 //!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │                           Cache System                                  │
+//! │                                                                         │
+//! │  ┌─────────────────────┐              ┌─────────────────────┐          │
+//! │  │       Policy        │              │        Store        │          │
+//! │  │  (eviction order)   │◄────────────►│   (key/value data)  │          │
+//! │  └─────────────────────┘   notifies   └─────────────────────┘          │
+//! │           │                                     │                       │
+//! │           │ manages                             │ implements            │
+//! │           ▼                                     ▼                       │
+//! │  ┌─────────────────────┐              ┌─────────────────────┐          │
+//! │  │  Policy Metadata    │              │   Store Traits      │          │
+//! │  │  - access order     │              │   - StoreCore       │          │
+//! │  │  - frequency counts │              │   - StoreMut        │          │
+//! │  │  - eviction hints   │              │   - ConcurrentStore │          │
+//! │  └─────────────────────┘              └─────────────────────┘          │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//!
+//! Trait Hierarchy
+//! ───────────────
+//!
+//! Single-threaded (direct ownership):
+//!
+//!     ┌──────────────────┐
+//!     │    StoreCore     │  get(&K) -> &V
+//!     │   (read-only)    │  contains, len, capacity
+//!     └────────┬─────────┘
+//!              │ extends
+//!              ▼
+//!     ┌──────────────────┐
+//!     │    StoreMut      │  try_insert(K, V) -> Result<Option<V>>
+//!     │   (read-write)   │  remove(&K) -> Option<V>
+//!     └──────────────────┘
+//!
+//! Concurrent (Arc-based ownership):
+//!
+//!     ┌──────────────────────┐
+//!     │ ConcurrentStoreRead  │  get(&K) -> Arc<V>
+//!     │     (read-only)      │  contains, len, capacity
+//!     └──────────┬───────────┘
+//!                │ extends
+//!                ▼
+//!     ┌──────────────────────┐
+//!     │   ConcurrentStore    │  try_insert(K, Arc<V>) -> Result<Option<Arc<V>>>
+//!     │    (read-write)      │  remove(&K) -> Option<Arc<V>>
+//!     └──────────────────────┘
+//!
+//! Factory Traits
+//! ──────────────
+//!
+//!     StoreFactory<K, V>           ConcurrentStoreFactory<K, V>
+//!            │                                │
+//!            ▼                                ▼
+//!     create(capacity)              create(capacity)
+//!            │                                │
+//!            ▼                                ▼
+//!     impl StoreMut<K, V>          impl ConcurrentStore<K, V>
+//! ```
+//!
 //! ## Ownership Model
 //!
 //! Single-threaded stores (`StoreCore` + `StoreMut`) use direct ownership:
@@ -19,17 +81,62 @@
 use std::sync::Arc;
 
 /// Snapshot of store-level metrics.
+///
+/// Provides a point-in-time view of store activity counters. All fields
+/// are cumulative since store creation.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::traits::StoreMetrics;
+///
+/// let metrics = StoreMetrics {
+///     hits: 150,
+///     misses: 50,
+///     inserts: 100,
+///     updates: 20,
+///     removes: 10,
+///     evictions: 40,
+/// };
+///
+/// let hit_rate = metrics.hits as f64 / (metrics.hits + metrics.misses) as f64;
+/// assert!((hit_rate - 0.75).abs() < f64::EPSILON);
+/// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StoreMetrics {
+    /// Number of successful lookups.
     pub hits: u64,
+    /// Number of failed lookups.
     pub misses: u64,
+    /// Number of new key insertions.
     pub inserts: u64,
+    /// Number of value updates for existing keys.
     pub updates: u64,
+    /// Number of explicit removals via `remove()`.
     pub removes: u64,
+    /// Number of entries evicted by the policy.
     pub evictions: u64,
 }
 
-/// Error returned when a store is at capacity.
+/// Error returned when inserting into a store at capacity.
+///
+/// This error occurs when calling `try_insert` with a new key on a store
+/// that has reached its maximum capacity. Updates to existing keys never
+/// trigger this error.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::traits::StoreFull;
+///
+/// fn handle_insert_result<V>(result: Result<Option<V>, StoreFull>) {
+///     match result {
+///         Ok(Some(old)) => println!("Updated existing entry"),
+///         Ok(None) => println!("Inserted new entry"),
+///         Err(StoreFull) => println!("Store is full, consider evicting"),
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StoreFull;
 
@@ -39,26 +146,69 @@ pub struct StoreFull;
 
 /// Read-only store operations for single-threaded backends.
 ///
-/// Returns borrowed references to avoid allocation overhead.
+/// Provides zero-cost access to stored values via borrowed references.
+/// Implementors manage key-value storage without concerning themselves
+/// with eviction logic—that's the policy's responsibility.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type, typically requires `Hash + Eq` for map-based stores
+/// - `V`: Value type, no trait bounds at the trait level
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::traits::{StoreCore, StoreMut, StoreMetrics};
+///
+/// // A minimal in-memory store implementation
+/// struct VecStore<K, V> {
+///     entries: Vec<(K, V)>,
+///     capacity: usize,
+/// }
+///
+/// impl<K: PartialEq, V> StoreCore<K, V> for VecStore<K, V> {
+///     fn get(&self, key: &K) -> Option<&V> {
+///         self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+///     }
+///
+///     fn contains(&self, key: &K) -> bool {
+///         self.entries.iter().any(|(k, _)| k == key)
+///     }
+///
+///     fn len(&self) -> usize {
+///         self.entries.len()
+///     }
+///
+///     fn capacity(&self) -> usize {
+///         self.capacity
+///     }
+/// }
+/// ```
 pub trait StoreCore<K, V> {
-    /// Fetch a reference to a value by key.
+    /// Returns a reference to the value for the given key.
+    ///
+    /// Returns `None` if the key is not present. Does not update access
+    /// metadata—that's handled by the policy layer.
     fn get(&self, key: &K) -> Option<&V>;
 
-    /// Check if a key exists.
+    /// Returns `true` if the key exists in the store.
     fn contains(&self, key: &K) -> bool;
 
-    /// Current number of entries.
+    /// Returns the current number of entries.
     fn len(&self) -> usize;
 
-    /// Check if the store is empty.
+    /// Returns `true` if the store contains no entries.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Maximum entries allowed.
+    /// Returns the maximum number of entries this store can hold.
     fn capacity(&self) -> usize;
 
-    /// Snapshot the store's current metrics.
+    /// Returns a snapshot of the store's metrics.
+    ///
+    /// Default implementation returns zeroed metrics. Override to provide
+    /// actual tracking.
     fn metrics(&self) -> StoreMetrics {
         StoreMetrics::default()
     }
@@ -66,17 +216,83 @@ pub trait StoreCore<K, V> {
 
 /// Mutable store operations for single-threaded backends.
 ///
-/// Takes and returns owned values directly—no `Arc` overhead.
+/// Extends [`StoreCore`] with write operations. Takes and returns owned
+/// values directly—no `Arc` overhead. The store does not perform eviction;
+/// it signals capacity via [`StoreFull`] and lets the policy decide what
+/// to evict.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::traits::{StoreCore, StoreMut, StoreFull};
+///
+/// struct VecStore<K, V> {
+///     entries: Vec<(K, V)>,
+///     capacity: usize,
+/// }
+///
+/// impl<K, V> VecStore<K, V> {
+///     fn new(capacity: usize) -> Self {
+///         Self { entries: Vec::with_capacity(capacity), capacity }
+///     }
+/// }
+///
+/// impl<K: PartialEq, V> StoreCore<K, V> for VecStore<K, V> {
+///     fn get(&self, key: &K) -> Option<&V> {
+///         self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+///     }
+///     fn contains(&self, key: &K) -> bool {
+///         self.entries.iter().any(|(k, _)| k == key)
+///     }
+///     fn len(&self) -> usize { self.entries.len() }
+///     fn capacity(&self) -> usize { self.capacity }
+/// }
+///
+/// impl<K: PartialEq, V> StoreMut<K, V> for VecStore<K, V> {
+///     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreFull> {
+///         // Check for existing key first
+///         if let Some(pos) = self.entries.iter().position(|(k, _)| k == &key) {
+///             let old = std::mem::replace(&mut self.entries[pos].1, value);
+///             return Ok(Some(old));
+///         }
+///         // New key—check capacity
+///         if self.entries.len() >= self.capacity {
+///             return Err(StoreFull);
+///         }
+///         self.entries.push((key, value));
+///         Ok(None)
+///     }
+///
+///     fn remove(&mut self, key: &K) -> Option<V> {
+///         self.entries.iter().position(|(k, _)| k == key)
+///             .map(|pos| self.entries.remove(pos).1)
+///     }
+///
+///     fn clear(&mut self) {
+///         self.entries.clear();
+///     }
+/// }
+///
+/// let mut store = VecStore::new(2);
+/// assert!(store.try_insert("a", 1).is_ok());
+/// assert!(store.try_insert("b", 2).is_ok());
+/// assert_eq!(store.try_insert("c", 3), Err(StoreFull));
+/// ```
 pub trait StoreMut<K, V>: StoreCore<K, V> {
-    /// Insert or update a value. Returns the previous value if present.
+    /// Inserts a key-value pair, returning the previous value if the key existed.
     ///
-    /// Returns `StoreFull` if at capacity and inserting a new key.
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if the store is at capacity and `key` is new.
+    /// Updates to existing keys always succeed.
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreFull>;
 
-    /// Remove a value by key, returning the owned value.
+    /// Removes and returns the value for the given key.
+    ///
+    /// Returns `None` if the key was not present.
     fn remove(&mut self, key: &K) -> Option<V>;
 
-    /// Remove all entries.
+    /// Removes all entries from the store.
     fn clear(&mut self);
 }
 
@@ -86,44 +302,180 @@ pub trait StoreMut<K, V>: StoreCore<K, V> {
 
 /// Read-only store operations for concurrent backends.
 ///
-/// Returns `Arc<V>` because references can't outlive lock guards.
+/// Returns `Arc<V>` because borrowed references cannot outlive lock guards
+/// in concurrent contexts. The `Arc` overhead is acceptable here since
+/// concurrent access already involves synchronization costs.
+///
+/// # Thread Safety
+///
+/// Implementors must be `Send + Sync`. Internal synchronization (mutex,
+/// RwLock, lock-free structures) is an implementation detail.
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, RwLock};
+/// use cachekit::store::traits::{ConcurrentStoreRead, StoreMetrics};
+///
+/// struct ConcurrentMapStore<K, V> {
+///     inner: RwLock<HashMap<K, Arc<V>>>,
+///     capacity: usize,
+/// }
+///
+/// impl<K, V> ConcurrentMapStore<K, V> {
+///     fn new(capacity: usize) -> Self {
+///         Self {
+///             inner: RwLock::new(HashMap::with_capacity(capacity)),
+///             capacity,
+///         }
+///     }
+/// }
+///
+/// impl<K: Eq + std::hash::Hash, V> ConcurrentStoreRead<K, V> for ConcurrentMapStore<K, V>
+/// where
+///     K: Send + Sync,
+///     V: Send + Sync,
+/// {
+///     fn get(&self, key: &K) -> Option<Arc<V>> {
+///         self.inner.read().unwrap().get(key).cloned()
+///     }
+///
+///     fn contains(&self, key: &K) -> bool {
+///         self.inner.read().unwrap().contains_key(key)
+///     }
+///
+///     fn len(&self) -> usize {
+///         self.inner.read().unwrap().len()
+///     }
+///
+///     fn capacity(&self) -> usize {
+///         self.capacity
+///     }
+/// }
+/// ```
 pub trait ConcurrentStoreRead<K, V>: Send + Sync {
-    /// Fetch a shared reference to a value by key.
+    /// Returns a shared handle to the value for the given key.
+    ///
+    /// The returned `Arc<V>` can be held across await points or passed
+    /// to other threads without lifetime concerns.
     fn get(&self, key: &K) -> Option<Arc<V>>;
 
-    /// Check if a key exists.
+    /// Returns `true` if the key exists in the store.
     fn contains(&self, key: &K) -> bool;
 
-    /// Current number of entries.
+    /// Returns the current number of entries.
+    ///
+    /// Note: In concurrent contexts, this value may be stale by the time
+    /// it's used.
     fn len(&self) -> usize;
 
-    /// Check if the store is empty.
+    /// Returns `true` if the store contains no entries.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Maximum entries allowed.
+    /// Returns the maximum number of entries this store can hold.
     fn capacity(&self) -> usize;
 
-    /// Snapshot the store's current metrics.
+    /// Returns a snapshot of the store's metrics.
     fn metrics(&self) -> StoreMetrics {
         StoreMetrics::default()
     }
 }
 
-/// Mutable store operations for concurrent backends (interior mutability).
+/// Mutable store operations for concurrent backends.
 ///
-/// Uses `Arc<V>` for values since multiple threads may hold references.
+/// Extends [`ConcurrentStoreRead`] with write operations using interior
+/// mutability. Methods take `&self` (not `&mut self`) enabling shared
+/// access across threads.
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, RwLock};
+/// use cachekit::store::traits::{
+///     ConcurrentStore, ConcurrentStoreRead, StoreFull, StoreMetrics,
+/// };
+///
+/// struct ConcurrentMapStore<K, V> {
+///     inner: RwLock<HashMap<K, Arc<V>>>,
+///     capacity: usize,
+/// }
+///
+/// impl<K, V> ConcurrentMapStore<K, V> {
+///     fn new(capacity: usize) -> Self {
+///         Self {
+///             inner: RwLock::new(HashMap::with_capacity(capacity)),
+///             capacity,
+///         }
+///     }
+/// }
+///
+/// impl<K: Eq + std::hash::Hash, V> ConcurrentStoreRead<K, V> for ConcurrentMapStore<K, V>
+/// where
+///     K: Send + Sync,
+///     V: Send + Sync,
+/// {
+///     fn get(&self, key: &K) -> Option<Arc<V>> {
+///         self.inner.read().unwrap().get(key).cloned()
+///     }
+///     fn contains(&self, key: &K) -> bool {
+///         self.inner.read().unwrap().contains_key(key)
+///     }
+///     fn len(&self) -> usize {
+///         self.inner.read().unwrap().len()
+///     }
+///     fn capacity(&self) -> usize {
+///         self.capacity
+///     }
+/// }
+///
+/// impl<K: Eq + std::hash::Hash, V> ConcurrentStore<K, V> for ConcurrentMapStore<K, V>
+/// where
+///     K: Send + Sync,
+///     V: Send + Sync,
+/// {
+///     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
+///         let mut guard = self.inner.write().unwrap();
+///         if guard.contains_key(&key) {
+///             return Ok(guard.insert(key, value));
+///         }
+///         if guard.len() >= self.capacity {
+///             return Err(StoreFull);
+///         }
+///         Ok(guard.insert(key, value))
+///     }
+///
+///     fn remove(&self, key: &K) -> Option<Arc<V>> {
+///         self.inner.write().unwrap().remove(key)
+///     }
+///
+///     fn clear(&self) {
+///         self.inner.write().unwrap().clear();
+///     }
+/// }
+///
+/// let store = ConcurrentMapStore::<&str, i32>::new(2);
+/// assert!(store.try_insert("a", Arc::new(1)).is_ok());
+/// assert!(store.try_insert("b", Arc::new(2)).is_ok());
+/// assert_eq!(store.try_insert("c", Arc::new(3)), Err(StoreFull));
+/// ```
 pub trait ConcurrentStore<K, V>: ConcurrentStoreRead<K, V> {
-    /// Insert or update a value. Returns the previous value if present.
+    /// Inserts a key-value pair, returning the previous value if the key existed.
     ///
-    /// Returns `StoreFull` if at capacity and inserting a new key.
+    /// Uses interior mutability—takes `&self` not `&mut self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreFull`] if the store is at capacity and `key` is new.
     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull>;
 
-    /// Remove a value by key.
+    /// Removes and returns the value for the given key.
     fn remove(&self, key: &K) -> Option<Arc<V>>;
 
-    /// Remove all entries.
+    /// Removes all entries from the store.
     fn clear(&self);
 }
 
@@ -131,18 +483,153 @@ pub trait ConcurrentStore<K, V>: ConcurrentStoreRead<K, V> {
 // Factory traits
 // =============================================================================
 
-/// Factory trait for creating single-threaded store instances.
+/// Factory for creating single-threaded store instances.
+///
+/// Enables generic cache construction without hard-coding a specific store
+/// implementation. Policies use this to create their backing storage.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::store::traits::{StoreCore, StoreMut, StoreFactory, StoreFull};
+///
+/// // A simple vec-backed store
+/// struct VecStore<K, V> {
+///     entries: Vec<(K, V)>,
+///     capacity: usize,
+/// }
+///
+/// impl<K: PartialEq, V> StoreCore<K, V> for VecStore<K, V> {
+///     fn get(&self, key: &K) -> Option<&V> {
+///         self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+///     }
+///     fn contains(&self, key: &K) -> bool {
+///         self.entries.iter().any(|(k, _)| k == key)
+///     }
+///     fn len(&self) -> usize { self.entries.len() }
+///     fn capacity(&self) -> usize { self.capacity }
+/// }
+///
+/// impl<K: PartialEq, V> StoreMut<K, V> for VecStore<K, V> {
+///     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreFull> {
+///         if let Some(pos) = self.entries.iter().position(|(k, _)| k == &key) {
+///             let old = std::mem::replace(&mut self.entries[pos].1, value);
+///             return Ok(Some(old));
+///         }
+///         if self.entries.len() >= self.capacity {
+///             return Err(StoreFull);
+///         }
+///         self.entries.push((key, value));
+///         Ok(None)
+///     }
+///     fn remove(&mut self, key: &K) -> Option<V> {
+///         self.entries.iter().position(|(k, _)| k == key)
+///             .map(|pos| self.entries.remove(pos).1)
+///     }
+///     fn clear(&mut self) { self.entries.clear(); }
+/// }
+///
+/// // Factory implementation
+/// struct VecStoreFactory;
+///
+/// impl<K: PartialEq, V> StoreFactory<K, V> for VecStoreFactory {
+///     type Store = VecStore<K, V>;
+///
+///     fn create(capacity: usize) -> Self::Store {
+///         VecStore {
+///             entries: Vec::with_capacity(capacity),
+///             capacity,
+///         }
+///     }
+/// }
+///
+/// // Generic function that works with any store factory
+/// fn make_store<F, K, V>(cap: usize) -> F::Store
+/// where
+///     F: StoreFactory<K, V>,
+/// {
+///     F::create(cap)
+/// }
+///
+/// let store: VecStore<String, i32> = make_store::<VecStoreFactory, _, _>(100);
+/// assert_eq!(store.capacity(), 100);
+/// ```
 pub trait StoreFactory<K, V> {
+    /// The concrete store type produced by this factory.
     type Store: StoreCore<K, V>;
 
-    /// Create a new store with the specified capacity.
+    /// Creates a new store with the specified capacity.
     fn create(capacity: usize) -> Self::Store;
 }
 
-/// Factory trait for creating concurrent store instances.
+/// Factory for creating concurrent store instances.
+///
+/// Same pattern as [`StoreFactory`] but for thread-safe stores.
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, RwLock};
+/// use cachekit::store::traits::{
+///     ConcurrentStore, ConcurrentStoreFactory, ConcurrentStoreRead, StoreFull,
+/// };
+///
+/// struct ConcurrentMapStore<K, V> {
+///     inner: RwLock<HashMap<K, Arc<V>>>,
+///     capacity: usize,
+/// }
+///
+/// // ... trait impls omitted for brevity (see ConcurrentStore example)
+/// # impl<K: Eq + std::hash::Hash + Send + Sync, V: Send + Sync> ConcurrentStoreRead<K, V>
+/// #     for ConcurrentMapStore<K, V>
+/// # {
+/// #     fn get(&self, key: &K) -> Option<Arc<V>> {
+/// #         self.inner.read().unwrap().get(key).cloned()
+/// #     }
+/// #     fn contains(&self, key: &K) -> bool {
+/// #         self.inner.read().unwrap().contains_key(key)
+/// #     }
+/// #     fn len(&self) -> usize { self.inner.read().unwrap().len() }
+/// #     fn capacity(&self) -> usize { self.capacity }
+/// # }
+/// # impl<K: Eq + std::hash::Hash + Send + Sync, V: Send + Sync> ConcurrentStore<K, V>
+/// #     for ConcurrentMapStore<K, V>
+/// # {
+/// #     fn try_insert(&self, key: K, value: Arc<V>) -> Result<Option<Arc<V>>, StoreFull> {
+/// #         let mut guard = self.inner.write().unwrap();
+/// #         if guard.len() >= self.capacity && !guard.contains_key(&key) {
+/// #             return Err(StoreFull);
+/// #         }
+/// #         Ok(guard.insert(key, value))
+/// #     }
+/// #     fn remove(&self, key: &K) -> Option<Arc<V>> {
+/// #         self.inner.write().unwrap().remove(key)
+/// #     }
+/// #     fn clear(&self) { self.inner.write().unwrap().clear(); }
+/// # }
+///
+/// struct ConcurrentMapStoreFactory;
+///
+/// impl<K, V> ConcurrentStoreFactory<K, V> for ConcurrentMapStoreFactory
+/// where
+///     K: Eq + std::hash::Hash + Send + Sync,
+///     V: Send + Sync,
+/// {
+///     type Store = ConcurrentMapStore<K, V>;
+///
+///     fn create(capacity: usize) -> Self::Store {
+///         ConcurrentMapStore {
+///             inner: RwLock::new(HashMap::with_capacity(capacity)),
+///             capacity,
+///         }
+///     }
+/// }
+/// ```
 pub trait ConcurrentStoreFactory<K, V> {
+    /// The concrete store type produced by this factory.
     type Store: ConcurrentStore<K, V>;
 
-    /// Create a new store with the specified capacity.
+    /// Creates a new store with the specified capacity.
     fn create(capacity: usize) -> Self::Store;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,57 +7,44 @@
 //! ## Architecture
 //!
 //! ```text
-//!                             ┌─────────────────────────────────────────┐
-//!                             │            CoreCache<K, V>              │
-//!                             │                                         │
-//!                             │  insert(&mut, K, V) → Option<V>         │
-//!                             │  get(&mut, &K) → Option<&V>             │
-//!                             │  contains(&, &K) → bool                 │
-//!                             │  len(&) → usize                         │
-//!                             │  is_empty(&) → bool                     │
-//!                             │  capacity(&) → usize                    │
-//!                             │  clear(&mut)                            │
-//!                             └──────────────────┬──────────────────────┘
-//!                                                │
-//!                    ┌───────────────────────────┼───────────────────────────┐
-//!                    │                           │                           │
-//!                    ▼                           ▼                           ▼
-//!   ┌────────────────────────────┐   ┌─────────────────────────┐
-//!   │   FifoCacheTrait<K, V>     │   │   MutableCache<K, V>    │
-//!   │                            │   │                         │
-//!   │  pop_oldest() → (K, V)     │   │  remove(&K) → Option<V> │
-//!   │  peek_oldest() → (&K, &V)  │   │  remove_batch(&[K])     │
-//!   │  pop_oldest_batch(n)       │   │                         │
-//!   │  age_rank(&K) → usize      │   └───────────┬─────────────┘
-//!   │                            │               │
-//!   │  No arbitrary removal!     │               │
-//!   └────────────────────────────┘               │
-//!                                    ┌───────────┴───────────┐
-//!                                    │                       │
-//!                                    ▼                       ▼
-//!                     ┌──────────────────────────┐  ┌────────────────────────┐
-//!                     │   LruCacheTrait<K, V>    │  │   LfuCacheTrait<K, V>  │
-//!                     │                          │  │                        │
-//!                     │  pop_lru() → (K, V)      │  │  pop_lfu() → (K, V)    │
-//!                     │  peek_lru() → (&K, &V)   │  │  peek_lfu() → (&K, &V) │
-//!                     │  touch(&K) → bool        │  │  frequency(&K) → u64   │
-//!                     │  recency_rank(&K)        │  │  reset_frequency(&K)   │
-//!                     │                          │  │  increment_frequency() │
-//!                     └──────────────────────────┘  └────────────────────────┘
-//!                                    │
-//!                                    ▼
-//!                     ┌──────────────────────────┐
-//!                     │  LrukCacheTrait<K, V>    │
-//!                     │                          │
-//!                     │  pop_lru_k() → (K, V)    │
-//!                     │  peek_lru_k() → (&K,&V)  │
-//!                     │  k_value() → usize       │
-//!                     │  access_history(&K)      │
-//!                     │  access_count(&K)        │
-//!                     │  k_distance(&K) → u64    │
-//!                     │  touch(&K) → bool        │
-//!                     │  k_distance_rank(&K)     │
-//!                     └──────────────────────────┘
+//!                          ┌─────────────────────────────────────────┐
+//!                          │            CoreCache<K, V>              │
+//!                          │                                         │
+//!                          │  insert(&mut, K, V) → Option<V>         │
+//!                          │  get(&mut, &K) → Option<&V>             │
+//!                          │  contains(&, &K) → bool                 │
+//!                          │  len(&) → usize                         │
+//!                          │  is_empty(&) → bool                     │
+//!                          │  capacity(&) → usize                    │
+//!                          │  clear(&mut)                            │
+//!                          └──────────────────┬──────────────────────┘
+//!                                             │
+//!                ┌────────────────────────────┴────────────────────────────┐
+//!                │                                                         │
+//!                ▼                                                         ▼
+//!   ┌────────────────────────────┐                          ┌─────────────────────────────┐
+//!   │   FifoCacheTrait<K, V>     │                          │    MutableCache<K, V>       │
+//!   │                            │                          │                             │
+//!   │  pop_oldest() → (K, V)     │                          │  remove(&K) → Option<V>     │
+//!   │  peek_oldest() → (&K, &V)  │                          │  remove_batch(&[K])         │
+//!   │  pop_oldest_batch(n)       │                          │                             │
+//!   │  age_rank(&K) → usize      │                          └──────────────┬──────────────┘
+//!   │                            │                                         │
+//!   │  ⚠ No arbitrary removal!   │          ┌──────────────────────────────┼──────────────────────────────┐
+//!   └────────────────────────────┘          │                              │                              │
+//!                                           ▼                              ▼                              ▼
+//!                          ┌────────────────────────────┐  ┌────────────────────────────┐  ┌────────────────────────────┐
+//!                          │   LruCacheTrait<K, V>      │  │   LfuCacheTrait<K, V>      │  │   LrukCacheTrait<K, V>     │
+//!                          │                            │  │                            │  │                            │
+//!                          │  pop_lru() → (K, V)        │  │  pop_lfu() → (K, V)        │  │  pop_lru_k() → (K, V)      │
+//!                          │  peek_lru() → (&K, &V)     │  │  peek_lfu() → (&K, &V)     │  │  peek_lru_k() → (&K, &V)   │
+//!                          │  touch(&K) → bool          │  │  frequency(&K) → u64       │  │  k_value() → usize         │
+//!                          │  recency_rank(&K) → usize  │  │  reset_frequency(&K)       │  │  access_history(&K)        │
+//!                          │                            │  │  increment_frequency(&K)   │  │  access_count(&K) → usize  │
+//!                          └────────────────────────────┘  └────────────────────────────┘  │  k_distance(&K) → u64      │
+//!                                                                                          │  touch(&K) → bool          │
+//!                                                                                          │  k_distance_rank(&K)       │
+//!                                                                                          └────────────────────────────┘
 //! ```
 //!
 //! ## Trait Design Philosophy
@@ -249,189 +236,1105 @@
 
 /// Core cache operations that all caches support.
 ///
-/// This trait focuses on the essential operations that make sense for any cache type,
+/// This trait defines the fundamental operations that make sense for any cache type,
 /// regardless of eviction policy. All policy-specific traits extend this.
+///
+/// # Type Parameters
+///
+/// - `K`: Key type (implementations typically require `Eq + Hash`)
+/// - `V`: Value type
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::CoreCache;
+/// use cachekit::policy::lru_k::LrukCache;
+///
+/// fn warm_cache<C: CoreCache<u64, String>>(cache: &mut C, data: &[(u64, String)]) {
+///     for (key, value) in data {
+///         cache.insert(*key, value.clone());
+///     }
+/// }
+///
+/// let mut cache = LrukCache::new(100);
+/// warm_cache(&mut cache, &[(1, "one".to_string()), (2, "two".to_string())]);
+/// assert_eq!(cache.len(), 2);
+/// ```
 pub trait CoreCache<K, V> {
-    /// Insert a key-value pair, returning the previous value if it existed
+    /// Inserts a key-value pair, returning the previous value if it existed.
+    ///
+    /// If the cache is at capacity, an entry may be evicted according to the
+    /// cache's eviction policy before the new entry is inserted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    ///
+    /// // New key returns None
+    /// assert_eq!(cache.insert(1, "first"), None);
+    ///
+    /// // Existing key returns previous value
+    /// assert_eq!(cache.insert(1, "second"), Some("first"));
+    /// ```
     fn insert(&mut self, key: K, value: V) -> Option<V>;
 
-    /// Get a value by key (may update internal state for access tracking)
+    /// Gets a reference to a value by key.
+    ///
+    /// May update internal state (access time, frequency) depending on the
+    /// eviction policy. Use [`contains`](Self::contains) if you only need
+    /// to check existence without affecting eviction order.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// cache.insert(1, "value");
+    ///
+    /// assert_eq!(cache.get(&1), Some(&"value"));
+    /// assert_eq!(cache.get(&99), None);
+    /// ```
     fn get(&mut self, key: &K) -> Option<&V>;
 
-    /// Check if a key exists without potentially updating access state
+    /// Checks if a key exists without updating access state.
+    ///
+    /// Unlike [`get`](Self::get), this does not affect eviction order.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// cache.insert(1, "value");
+    ///
+    /// assert!(cache.contains(&1));
+    /// assert!(!cache.contains(&99));
+    /// ```
     fn contains(&self, key: &K) -> bool;
 
-    /// Get the current number of entries
+    /// Returns the current number of entries in the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// assert_eq!(cache.len(), 0);
+    ///
+    /// cache.insert(1, "one");
+    /// cache.insert(2, "two");
+    /// assert_eq!(cache.len(), 2);
+    /// ```
     fn len(&self) -> usize;
 
-    /// Check if the cache is empty
+    /// Returns `true` if the cache contains no entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache: LrukCache<u64, &str> = LrukCache::new(10);
+    /// assert!(cache.is_empty());
+    ///
+    /// cache.insert(1, "value");
+    /// assert!(!cache.is_empty());
+    /// ```
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Get the maximum capacity
+    /// Returns the maximum capacity of the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let cache: LrukCache<u64, &str> = LrukCache::new(100);
+    /// assert_eq!(cache.capacity(), 100);
+    /// ```
     fn capacity(&self) -> usize;
 
-    /// Remove all entries
+    /// Removes all entries from the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::CoreCache;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// cache.insert(1, "one");
+    /// cache.insert(2, "two");
+    /// assert_eq!(cache.len(), 2);
+    ///
+    /// cache.clear();
+    /// assert!(cache.is_empty());
+    /// ```
     fn clear(&mut self);
 }
 
-/// Caches that support arbitrary key-based removal
-/// This is appropriate for LRU, LFU, and general hash-map style caches
+/// Caches that support arbitrary key-based removal.
+///
+/// This trait extends [`CoreCache`] with the ability to remove entries by key.
+/// Appropriate for LRU, LFU, and general hash-map style caches where arbitrary
+/// removal doesn't violate policy semantics.
+///
+/// **Note**: FIFO caches intentionally do NOT implement this trait because
+/// arbitrary removal would violate FIFO semantics. Use [`FifoCacheTrait`] instead.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::{CoreCache, MutableCache};
+/// use cachekit::policy::lru_k::LrukCache;
+///
+/// fn invalidate_keys<C: MutableCache<u64, String>>(cache: &mut C, keys: &[u64]) {
+///     for key in keys {
+///         cache.remove(key);
+///     }
+/// }
+///
+/// let mut cache = LrukCache::new(100);
+/// cache.insert(1, "one".to_string());
+/// cache.insert(2, "two".to_string());
+/// cache.insert(3, "three".to_string());
+///
+/// invalidate_keys(&mut cache, &[1, 3]);
+/// assert!(!cache.contains(&1));
+/// assert!(cache.contains(&2));
+/// assert!(!cache.contains(&3));
+/// ```
 pub trait MutableCache<K, V>: CoreCache<K, V> {
-    /// Remove a specific key-value pair
-    /// Returns the removed value if the key existed
+    /// Removes a specific key-value pair.
+    ///
+    /// Returns the removed value if the key existed, or `None` if it didn't.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, MutableCache};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// cache.insert(1, "value");
+    ///
+    /// assert_eq!(cache.remove(&1), Some("value"));
+    /// assert_eq!(cache.remove(&1), None);  // Already removed
+    /// ```
     fn remove(&mut self, key: &K) -> Option<V>;
 
-    /// Remove multiple keys efficiently
+    /// Removes multiple keys efficiently.
+    ///
+    /// Returns a vector of `Option<V>` in the same order as the input keys.
+    /// The default implementation loops over [`remove`](Self::remove).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, MutableCache};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::new(10);
+    /// cache.insert(1, "one");
+    /// cache.insert(2, "two");
+    /// cache.insert(3, "three");
+    ///
+    /// let removed = cache.remove_batch(&[1, 99, 3]);
+    /// assert_eq!(removed, vec![Some("one"), None, Some("three")]);
+    /// assert_eq!(cache.len(), 1);
+    /// ```
     fn remove_batch(&mut self, keys: &[K]) -> Vec<Option<V>> {
         keys.iter().map(|k| self.remove(k)).collect()
     }
 }
 
-/// FIFO-specific operations that respect insertion order
-/// No arbitrary removal - only ordered operations that maintain FIFO semantics
+/// FIFO-specific operations that respect insertion order.
+///
+/// This trait extends [`CoreCache`] with FIFO-appropriate operations.
+/// Importantly, it does NOT extend [`MutableCache`] because arbitrary removal
+/// would violate FIFO semantics (insertion order tracking).
+///
+/// # Design Rationale
+///
+/// FIFO caches evict in insertion order. If we allowed `remove(&key)`:
+/// - The queue would have "holes"
+/// - `age_rank()` would need expensive O(n) scanning
+/// - True insertion order would be lost
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::{CoreCache, FifoCacheTrait};
+/// use cachekit::policy::fifo::FifoCache;
+///
+/// let mut cache = FifoCache::new(3);
+/// cache.insert(1, "first");
+/// cache.insert(2, "second");
+/// cache.insert(3, "third");
+///
+/// // Peek without removing
+/// assert_eq!(cache.peek_oldest(), Some((&1, &"first")));
+///
+/// // Pop oldest entry
+/// assert_eq!(cache.pop_oldest(), Some((1, "first")));
+/// assert_eq!(cache.len(), 2);
+///
+/// // Age rank (0 = oldest)
+/// assert_eq!(cache.age_rank(&2), Some(0));  // Now oldest
+/// assert_eq!(cache.age_rank(&3), Some(1));
+/// ```
 pub trait FifoCacheTrait<K, V>: CoreCache<K, V> {
-    /// Remove and return the oldest entry (first inserted)
+    /// Removes and returns the oldest entry (first inserted).
+    ///
+    /// Returns `None` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, FifoCacheTrait};
+    /// use cachekit::policy::fifo::FifoCache;
+    ///
+    /// let mut cache = FifoCache::new(10);
+    /// cache.insert(1, "first");
+    /// cache.insert(2, "second");
+    ///
+    /// assert_eq!(cache.pop_oldest(), Some((1, "first")));
+    /// assert_eq!(cache.pop_oldest(), Some((2, "second")));
+    /// assert_eq!(cache.pop_oldest(), None);
+    /// ```
     fn pop_oldest(&mut self) -> Option<(K, V)>;
 
-    /// Peek at the oldest entry without removing it
+    /// Peeks at the oldest entry without removing it.
+    ///
+    /// Returns `None` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, FifoCacheTrait};
+    /// use cachekit::policy::fifo::FifoCache;
+    ///
+    /// let mut cache = FifoCache::new(10);
+    /// cache.insert(1, "first");
+    ///
+    /// // Peek doesn't remove
+    /// assert_eq!(cache.peek_oldest(), Some((&1, &"first")));
+    /// assert_eq!(cache.peek_oldest(), Some((&1, &"first")));
+    /// assert_eq!(cache.len(), 1);
+    /// ```
     fn peek_oldest(&self) -> Option<(&K, &V)>;
 
-    /// Remove multiple oldest entries efficiently
+    /// Removes multiple oldest entries efficiently.
+    ///
+    /// Returns up to `count` entries in FIFO order (oldest first).
+    /// The default implementation calls [`pop_oldest`](Self::pop_oldest) in a loop.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, FifoCacheTrait};
+    /// use cachekit::policy::fifo::FifoCache;
+    ///
+    /// let mut cache = FifoCache::new(10);
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(3, "c");
+    ///
+    /// let batch = cache.pop_oldest_batch(2);
+    /// assert_eq!(batch, vec![(1, "a"), (2, "b")]);
+    /// assert_eq!(cache.len(), 1);
+    /// ```
     fn pop_oldest_batch(&mut self, count: usize) -> Vec<(K, V)> {
         (0..count).filter_map(|_| self.pop_oldest()).collect()
     }
 
-    /// Get the age rank of a key (0 = oldest, higher = newer)
-    /// Returns None if key not found
+    /// Gets the age rank of a key (0 = oldest, higher = newer).
+    ///
+    /// Returns `None` if the key is not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, FifoCacheTrait};
+    /// use cachekit::policy::fifo::FifoCache;
+    ///
+    /// let mut cache = FifoCache::new(10);
+    /// cache.insert(1, "first");
+    /// cache.insert(2, "second");
+    /// cache.insert(3, "third");
+    ///
+    /// assert_eq!(cache.age_rank(&1), Some(0));  // Oldest
+    /// assert_eq!(cache.age_rank(&2), Some(1));
+    /// assert_eq!(cache.age_rank(&3), Some(2));  // Newest
+    /// assert_eq!(cache.age_rank(&99), None);    // Not found
+    /// ```
     fn age_rank(&self, key: &K) -> Option<usize>;
 }
 
-/// LRU-specific operations that respect access order
+/// LRU-specific operations that respect access order.
+///
+/// This trait extends [`MutableCache`] with LRU-specific eviction and access
+/// tracking operations. Entries are ordered by recency—the least recently
+/// accessed entry is evicted first.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use cachekit::traits::{CoreCache, MutableCache, LruCacheTrait};
+/// use cachekit::policy::lru::LruCore;
+///
+/// let mut cache: LruCore<u64, &str> = LruCore::new(3);
+/// cache.insert(1, Arc::new("first"));
+/// cache.insert(2, Arc::new("second"));
+/// cache.insert(3, Arc::new("third"));
+///
+/// // Access key 1 to make it MRU
+/// cache.get(&1);
+///
+/// // Key 2 is now LRU
+/// assert_eq!(cache.peek_lru().map(|(k, _)| *k), Some(2));
+///
+/// // Touch without retrieving value
+/// assert!(cache.touch(&2));  // Now key 3 is LRU
+///
+/// // Pop LRU entry
+/// let (key, _) = cache.pop_lru().unwrap();
+/// assert_eq!(key, 3);
+/// ```
 pub trait LruCacheTrait<K, V>: MutableCache<K, V> {
-    /// Remove and return the least recently used entry
+    /// Removes and returns the least recently used entry.
+    ///
+    /// Returns `None` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LruCacheTrait};
+    /// use cachekit::policy::lru::LruCore;
+    ///
+    /// let mut cache: LruCore<u64, &str> = LruCore::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    ///
+    /// let (key, _) = cache.pop_lru().unwrap();
+    /// assert_eq!(key, 1);  // First inserted, not accessed since
+    /// ```
     fn pop_lru(&mut self) -> Option<(K, V)>;
 
-    /// Peek at the LRU entry without removing it
+    /// Peeks at the LRU entry without removing it.
+    ///
+    /// Returns `None` if the cache is empty. Does not update access time.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LruCacheTrait};
+    /// use cachekit::policy::lru::LruCore;
+    ///
+    /// let mut cache: LruCore<u64, &str> = LruCore::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    ///
+    /// // Peek doesn't affect order
+    /// assert_eq!(cache.peek_lru().map(|(k, _)| *k), Some(1));
+    /// assert_eq!(cache.peek_lru().map(|(k, _)| *k), Some(1));
+    /// ```
     fn peek_lru(&self) -> Option<(&K, &V)>;
 
-    /// Touch an entry to mark it as recently used without retrieving the value
-    /// Returns true if the key was found and touched
+    /// Marks an entry as recently used without retrieving the value.
+    ///
+    /// Returns `true` if the key was found and touched, `false` otherwise.
+    /// This is useful for refreshing eviction order without fetching data.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LruCacheTrait};
+    /// use cachekit::policy::lru::LruCore;
+    ///
+    /// let mut cache: LruCore<u64, &str> = LruCore::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    ///
+    /// // Key 1 is LRU
+    /// assert_eq!(cache.peek_lru().map(|(k, _)| *k), Some(1));
+    ///
+    /// // Touch key 1 to make it MRU
+    /// assert!(cache.touch(&1));
+    ///
+    /// // Now key 2 is LRU
+    /// assert_eq!(cache.peek_lru().map(|(k, _)| *k), Some(2));
+    ///
+    /// // Touch non-existent key returns false
+    /// assert!(!cache.touch(&99));
+    /// ```
     fn touch(&mut self, key: &K) -> bool;
 
-    /// Get the recency rank of a key (0 = most recent, higher = less recent)
-    /// Returns None if key not found
+    /// Gets the recency rank of a key (0 = most recent, higher = less recent).
+    ///
+    /// Returns `None` if the key is not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LruCacheTrait};
+    /// use cachekit::policy::lru::LruCore;
+    ///
+    /// let mut cache: LruCore<u64, &str> = LruCore::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    /// cache.insert(3, Arc::new("third"));
+    ///
+    /// // Most recent insertion is rank 0
+    /// assert_eq!(cache.recency_rank(&3), Some(0));
+    /// assert_eq!(cache.recency_rank(&2), Some(1));
+    /// assert_eq!(cache.recency_rank(&1), Some(2));  // Oldest
+    /// assert_eq!(cache.recency_rank(&99), None);
+    /// ```
     fn recency_rank(&self, key: &K) -> Option<usize>;
 }
 
-/// LFU-specific operations that respect frequency order
+/// LFU-specific operations that respect frequency order.
+///
+/// This trait extends [`MutableCache`] with LFU-specific eviction and frequency
+/// tracking operations. Entries are ordered by access frequency—the least
+/// frequently accessed entry is evicted first.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use cachekit::traits::{CoreCache, MutableCache, LfuCacheTrait};
+/// use cachekit::policy::lfu::LfuCache;
+///
+/// let mut cache: LfuCache<u64, &str> = LfuCache::new(3);
+/// cache.insert(1, Arc::new("first"));
+/// cache.insert(2, Arc::new("second"));
+/// cache.insert(3, Arc::new("third"));
+///
+/// // Access key 1 multiple times
+/// cache.get(&1);
+/// cache.get(&1);
+/// cache.get(&1);
+///
+/// // Key 1 now has frequency 4 (1 insert + 3 gets)
+/// assert_eq!(cache.frequency(&1), Some(4));
+///
+/// // Key 2 has frequency 1 (just insert)
+/// assert_eq!(cache.frequency(&2), Some(1));
+///
+/// // Pop LFU (key 2 or 3, both have freq=1)
+/// let (key, _) = cache.pop_lfu().unwrap();
+/// assert!(key == 2 || key == 3);
+/// ```
 pub trait LfuCacheTrait<K, V>: MutableCache<K, V> {
-    /// Remove and return the least frequently used entry
+    /// Removes and returns the least frequently used entry.
+    ///
+    /// If multiple entries have the same frequency, eviction order depends
+    /// on the implementation (typically FIFO among same-frequency entries).
+    /// Returns `None` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LfuCacheTrait};
+    /// use cachekit::policy::lfu::LfuCache;
+    ///
+    /// let mut cache: LfuCache<u64, &str> = LfuCache::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    ///
+    /// // Access key 2 to increase its frequency
+    /// cache.get(&2);
+    ///
+    /// // Key 1 is LFU (freq=1 vs freq=2)
+    /// let (key, _) = cache.pop_lfu().unwrap();
+    /// assert_eq!(key, 1);
+    /// ```
     fn pop_lfu(&mut self) -> Option<(K, V)>;
 
-    /// Peek at the LFU entry without removing it
+    /// Peeks at the LFU entry without removing it.
+    ///
+    /// Returns `None` if the cache is empty. Does not increment frequency.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LfuCacheTrait};
+    /// use cachekit::policy::lfu::LfuCache;
+    ///
+    /// let mut cache: LfuCache<u64, &str> = LfuCache::new(10);
+    /// cache.insert(1, Arc::new("first"));
+    /// cache.insert(2, Arc::new("second"));
+    /// cache.get(&2);  // freq=2
+    ///
+    /// // Key 1 is LFU
+    /// assert_eq!(cache.peek_lfu().map(|(k, _)| *k), Some(1));
+    /// ```
     fn peek_lfu(&self) -> Option<(&K, &V)>;
 
-    /// Get the access frequency for a key
+    /// Gets the access frequency for a key.
+    ///
+    /// Returns `None` if the key is not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LfuCacheTrait};
+    /// use cachekit::policy::lfu::LfuCache;
+    ///
+    /// let mut cache: LfuCache<u64, &str> = LfuCache::new(10);
+    /// cache.insert(1, Arc::new("value"));
+    /// assert_eq!(cache.frequency(&1), Some(1));
+    ///
+    /// cache.get(&1);
+    /// assert_eq!(cache.frequency(&1), Some(2));
+    ///
+    /// assert_eq!(cache.frequency(&99), None);
+    /// ```
     fn frequency(&self, key: &K) -> Option<u64>;
 
-    /// Reset the frequency counter for a key to 1
-    /// Returns the old frequency if the key existed
+    /// Resets the frequency counter for a key to 1.
+    ///
+    /// Returns the old frequency if the key existed, `None` otherwise.
+    /// Useful for demoting hot entries after access pattern changes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LfuCacheTrait};
+    /// use cachekit::policy::lfu::LfuCache;
+    ///
+    /// let mut cache: LfuCache<u64, &str> = LfuCache::new(10);
+    /// cache.insert(1, Arc::new("value"));
+    /// cache.get(&1);
+    /// cache.get(&1);
+    /// assert_eq!(cache.frequency(&1), Some(3));
+    ///
+    /// // Reset to 1
+    /// assert_eq!(cache.reset_frequency(&1), Some(3));
+    /// assert_eq!(cache.frequency(&1), Some(1));
+    /// ```
     fn reset_frequency(&mut self, key: &K) -> Option<u64>;
 
-    /// Increment frequency without accessing the value
-    /// Returns the new frequency if the key existed
+    /// Increments frequency without accessing the value.
+    ///
+    /// Returns the new frequency if the key existed, `None` otherwise.
+    /// Useful for boosting priority without triggering value access.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use cachekit::traits::{CoreCache, LfuCacheTrait};
+    /// use cachekit::policy::lfu::LfuCache;
+    ///
+    /// let mut cache: LfuCache<u64, &str> = LfuCache::new(10);
+    /// cache.insert(1, Arc::new("value"));
+    /// assert_eq!(cache.frequency(&1), Some(1));
+    ///
+    /// // Boost without accessing
+    /// assert_eq!(cache.increment_frequency(&1), Some(2));
+    /// assert_eq!(cache.increment_frequency(&1), Some(3));
+    ///
+    /// assert_eq!(cache.increment_frequency(&99), None);
+    /// ```
     fn increment_frequency(&mut self, key: &K) -> Option<u64>;
 }
 
-/// LRU-K specific operations that respect K-distance access patterns
+/// LRU-K specific operations that respect K-distance access patterns.
+///
+/// This trait extends [`MutableCache`] with LRU-K-specific eviction and access
+/// history tracking. Unlike standard LRU which considers only the last access,
+/// LRU-K tracks the K-th most recent access time, providing scan resistance.
+///
+/// # Scan Resistance
+///
+/// LRU-K protects the cache from pollution by one-time scans. An entry needs
+/// K accesses before it can displace frequently-accessed entries.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::{CoreCache, MutableCache, LrukCacheTrait};
+/// use cachekit::policy::lru_k::LrukCache;
+///
+/// // Create LRU-2 cache (K=2)
+/// let mut cache = LrukCache::with_k(100, 2);
+/// cache.insert(1, "value");
+///
+/// // After insert, access_count is 1
+/// assert_eq!(cache.access_count(&1), Some(1));
+///
+/// // No K-distance yet (need K=2 accesses)
+/// assert_eq!(cache.k_distance(&1), None);
+///
+/// // Second access establishes K-distance
+/// cache.get(&1);
+/// assert_eq!(cache.access_count(&1), Some(2));
+/// assert!(cache.k_distance(&1).is_some());
+///
+/// // Access history (most recent first)
+/// let history = cache.access_history(&1).unwrap();
+/// assert_eq!(history.len(), 2);
+/// ```
 pub trait LrukCacheTrait<K, V>: MutableCache<K, V> {
-    /// Remove and return the entry with the oldest K-th access time
+    /// Removes and returns the entry with the oldest K-th access time.
+    ///
+    /// Entries with fewer than K accesses are evicted first (cold entries).
+    /// Returns `None` if the cache is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 2);
+    /// cache.insert(1, "first");
+    /// cache.insert(2, "second");
+    ///
+    /// // Access key 2 twice (makes it "hot")
+    /// cache.get(&2);
+    ///
+    /// // Key 1 is evicted first (only 1 access, K=2 not reached)
+    /// let (key, _) = cache.pop_lru_k().unwrap();
+    /// assert_eq!(key, 1);
+    /// ```
     fn pop_lru_k(&mut self) -> Option<(K, V)>;
 
-    /// Peek at the LRU-K entry without removing it
+    /// Peeks at the LRU-K entry without removing it.
+    ///
+    /// Returns `None` if the cache is empty. Does not update access history.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 2);
+    /// cache.insert(1, "first");
+    /// cache.insert(2, "second");
+    /// cache.get(&2);  // Second access for key 2
+    ///
+    /// // Key 1 is LRU-K (cold, only 1 access)
+    /// assert_eq!(cache.peek_lru_k().map(|(k, _)| *k), Some(1));
+    /// ```
     fn peek_lru_k(&self) -> Option<(&K, &V)>;
 
-    /// Get the K value used by this cache
+    /// Gets the K value used by this cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::LrukCacheTrait;
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let cache: LrukCache<u64, &str> = LrukCache::with_k(100, 3);
+    /// assert_eq!(cache.k_value(), 3);
+    ///
+    /// // Default K=2
+    /// let default_cache: LrukCache<u64, &str> = LrukCache::new(100);
+    /// assert_eq!(default_cache.k_value(), 2);
+    /// ```
     fn k_value(&self) -> usize;
 
-    /// Get the access history for a key (most recent first)
-    /// Returns None if key not found
+    /// Gets the access history for a key (most recent first).
+    ///
+    /// Returns up to K timestamps. Returns `None` if key not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 3);
+    /// cache.insert(1, "value");
+    /// cache.get(&1);
+    /// cache.get(&1);
+    ///
+    /// let history = cache.access_history(&1).unwrap();
+    /// assert_eq!(history.len(), 3);  // 1 insert + 2 gets, up to K=3
+    /// // history[0] is most recent, history[2] is oldest
+    /// ```
     fn access_history(&self, key: &K) -> Option<Vec<u64>>;
 
-    /// Get the number of recorded accesses for a key
+    /// Gets the number of recorded accesses for a key.
+    ///
+    /// Returns `None` if the key is not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 5);
+    /// cache.insert(1, "value");
+    /// assert_eq!(cache.access_count(&1), Some(1));
+    ///
+    /// cache.get(&1);
+    /// cache.get(&1);
+    /// assert_eq!(cache.access_count(&1), Some(3));
+    ///
+    /// // Capped at K
+    /// cache.get(&1);
+    /// cache.get(&1);
+    /// cache.get(&1);
+    /// assert_eq!(cache.access_count(&1), Some(5));  // Max K=5
+    /// ```
     fn access_count(&self, key: &K) -> Option<usize>;
 
-    /// Get the K-th most recent access time for a key (if it has K accesses)
-    /// Returns None if key not found or has fewer than K accesses
+    /// Gets the K-th most recent access time for a key.
+    ///
+    /// Returns `None` if the key is not found or has fewer than K accesses.
+    /// This is the core metric for LRU-K eviction decisions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 2);
+    /// cache.insert(1, "value");
+    ///
+    /// // Only 1 access, no K-distance yet
+    /// assert_eq!(cache.k_distance(&1), None);
+    ///
+    /// // Second access establishes K-distance
+    /// cache.get(&1);
+    /// assert!(cache.k_distance(&1).is_some());
+    /// ```
     fn k_distance(&self, key: &K) -> Option<u64>;
 
-    /// Touch an entry to record an access without retrieving the value
-    /// Returns true if the key was found and touched
+    /// Records an access without retrieving the value.
+    ///
+    /// Returns `true` if the key was found and touched, `false` otherwise.
+    /// This updates the access history for the entry.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 2);
+    /// cache.insert(1, "value");
+    /// assert_eq!(cache.access_count(&1), Some(1));
+    ///
+    /// // Touch to record access
+    /// assert!(cache.touch(&1));
+    /// assert_eq!(cache.access_count(&1), Some(2));
+    ///
+    /// // Touch non-existent key
+    /// assert!(!cache.touch(&99));
+    /// ```
     fn touch(&mut self, key: &K) -> bool;
 
-    /// Get the rank of a key based on K-distance (0 = oldest K-distance, higher = newer K-distance)
-    /// Entries with fewer than K accesses are ranked by their earliest access time
-    /// Returns None if key not found
+    /// Gets the rank of a key based on K-distance.
+    ///
+    /// Lower rank (0) means oldest K-distance (first to be evicted).
+    /// Entries with fewer than K accesses are ranked by their earliest access time.
+    /// Returns `None` if key not found.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cachekit::traits::{CoreCache, LrukCacheTrait};
+    /// use cachekit::policy::lru_k::LrukCache;
+    ///
+    /// let mut cache = LrukCache::with_k(10, 2);
+    /// cache.insert(1, "first");
+    /// cache.insert(2, "second");
+    ///
+    /// // Both have 1 access (cold), ranked by insertion order
+    /// assert_eq!(cache.k_distance_rank(&1), Some(0));  // Oldest
+    /// assert_eq!(cache.k_distance_rank(&2), Some(1));
+    /// ```
     fn k_distance_rank(&self, key: &K) -> Option<usize>;
 }
 
-/// Marker trait for caches that are safe to use concurrently
-/// Implementors guarantee thread-safe operations
+/// Marker trait for caches that are safe to use concurrently.
+///
+/// Implementors guarantee thread-safe operations. This trait extends
+/// `Send + Sync` and can be used as a bound to require concurrent access.
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::{CoreCache, ConcurrentCache};
+///
+/// // Function requiring a thread-safe cache
+/// fn use_from_threads<K, V, C>(cache: &C)
+/// where
+///     K: Send + Sync,
+///     V: Send + Sync,
+///     C: CoreCache<K, V> + ConcurrentCache,
+/// {
+///     // Safe to share between threads
+/// }
+/// ```
+///
+/// # Thread Safety
+///
+/// Individual cache implementations are NOT thread-safe by default.
+/// To use a non-concurrent cache from multiple threads, wrap it:
+///
+/// ```
+/// use std::sync::{Arc, RwLock};
+/// use cachekit::traits::CoreCache;
+/// use cachekit::policy::lru_k::LrukCache;
+///
+/// let cache = Arc::new(RwLock::new(LrukCache::<u64, String>::new(100)));
+///
+/// // Clone for use in another thread
+/// let cache_clone = cache.clone();
+/// std::thread::spawn(move || {
+///     let mut guard = cache_clone.write().unwrap();
+///     guard.insert(1, "value".to_string());
+/// });
+/// ```
 pub trait ConcurrentCache: Send + Sync {}
 
-/// High-level cache tier management
+/// High-level cache tier management.
+///
+/// This trait defines a multi-tier cache architecture where entries can be
+/// promoted or demoted between tiers based on access patterns:
+///
+/// - **Hot tier**: Frequently accessed data (LRU-managed)
+/// - **Warm tier**: Moderately accessed data (LFU-managed)
+/// - **Cold tier**: Rarely accessed data (FIFO-managed)
+///
+/// # Architecture
+///
+/// ```text
+/// ┌──────────────┐    promote()    ┌──────────────┐    promote()    ┌──────────────┐
+/// │  Cold Tier   │ ───────────────►│  Warm Tier   │───────────────► │   Hot Tier   │
+/// │  (FIFO)      │                 │  (LFU)       │                 │   (LRU)      │
+/// │              │◄─────────────── │              │◄───────────────  │              │
+/// └──────────────┘    demote()     └──────────────┘    demote()     └──────────────┘
+/// ```
+///
+/// # Associated Types
+///
+/// - `HotCache`: LRU-based cache for frequently accessed data
+/// - `WarmCache`: LFU-based cache for moderately accessed data
+/// - `ColdCache`: FIFO-based cache for cold/new data
 pub trait CacheTierManager<K, V> {
+    /// LRU-based cache for hot (frequently accessed) data.
     type HotCache: LruCacheTrait<K, V> + ConcurrentCache;
+
+    /// LFU-based cache for warm (moderately accessed) data.
     type WarmCache: LfuCacheTrait<K, V> + ConcurrentCache;
+
+    /// FIFO-based cache for cold (rarely accessed) data.
     type ColdCache: FifoCacheTrait<K, V> + ConcurrentCache;
 
-    /// Promote an entry from a lower tier to a higher tier
+    /// Promotes an entry from a lower tier to a higher tier.
+    ///
+    /// Returns `true` if the promotion was successful, `false` if the key
+    /// wasn't found in the source tier.
     fn promote(&mut self, key: &K, from_tier: CacheTier, to_tier: CacheTier) -> bool;
 
-    /// Demote an entry from a higher tier to a lower tier
+    /// Demotes an entry from a higher tier to a lower tier.
+    ///
+    /// Returns `true` if the demotion was successful, `false` if the key
+    /// wasn't found in the source tier.
     fn demote(&mut self, key: &K, from_tier: CacheTier, to_tier: CacheTier) -> bool;
 
-    /// Get the tier where a key currently resides
+    /// Gets the tier where a key currently resides.
+    ///
+    /// Returns `None` if the key is not in any tier.
     fn locate_key(&self, key: &K) -> Option<CacheTier>;
 
-    /// Force eviction from a specific tier
+    /// Forces eviction from a specific tier.
+    ///
+    /// Returns the evicted entry, or `None` if the tier is empty.
     fn evict_from_tier(&mut self, tier: CacheTier) -> Option<(K, V)>;
 }
 
-/// Cache tier enumeration
+/// Cache tier enumeration for multi-tier cache architectures.
+///
+/// Used with [`CacheTierManager`] to specify which tier to promote to,
+/// demote from, or query.
+///
+/// # Tier Characteristics
+///
+/// | Tier | Access Pattern | Eviction Policy | Typical Use |
+/// |------|----------------|-----------------|-------------|
+/// | Hot  | Frequent       | LRU             | Active working set |
+/// | Warm | Moderate       | LFU             | Periodically accessed |
+/// | Cold | Rare           | FIFO            | New or stale data |
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::CacheTier;
+///
+/// let tier = CacheTier::Hot;
+/// assert_eq!(tier, CacheTier::Hot);
+///
+/// // Tiers can be compared and hashed
+/// use std::collections::HashSet;
+/// let mut tiers = HashSet::new();
+/// tiers.insert(CacheTier::Hot);
+/// tiers.insert(CacheTier::Warm);
+/// tiers.insert(CacheTier::Cold);
+/// assert_eq!(tiers.len(), 3);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CacheTier {
-    /// Hot tier: frequently accessed data (LRU-managed)
+    /// Hot tier: frequently accessed data (LRU-managed).
+    ///
+    /// Best for: active working set, recently accessed entries.
     Hot,
-    /// Warm tier: moderately accessed data (LFU-managed)
+
+    /// Warm tier: moderately accessed data (LFU-managed).
+    ///
+    /// Best for: periodically accessed entries, stable hot spots.
     Warm,
-    /// Cold tier: rarely accessed data (FIFO-managed)
+
+    /// Cold tier: rarely accessed data (FIFO-managed).
+    ///
+    /// Best for: new entries, infrequently accessed data.
     Cold,
 }
 
-/// Factory trait for creating cache instances
+/// Factory trait for creating cache instances.
+///
+/// Provides a standard interface for cache construction, allowing generic
+/// code to create cache instances without knowing the concrete type.
+///
+/// # Associated Types
+///
+/// - `Cache`: The concrete cache type produced by this factory
+///
+/// # Example
+///
+/// ```ignore
+/// use cachekit::traits::{CoreCache, CacheFactory, CacheConfig};
+///
+/// struct LruFactory;
+///
+/// impl CacheFactory<u64, String> for LruFactory {
+///     type Cache = LruCache<u64, String>;
+///
+///     fn create(capacity: usize) -> Self::Cache {
+///         LruCache::new(capacity)
+///     }
+///
+///     fn create_with_config(config: CacheConfig) -> Self::Cache {
+///         LruCache::new(config.capacity)
+///     }
+/// }
+///
+/// // Generic function using factory
+/// fn build_cache<F: CacheFactory<u64, String>>() -> F::Cache {
+///     F::create(100)
+/// }
+/// ```
 pub trait CacheFactory<K, V> {
+    /// The concrete cache type produced by this factory.
     type Cache: CoreCache<K, V>;
 
-    /// Create a new cache instance with the specified capacity
+    /// Creates a new cache instance with the specified capacity.
     fn create(capacity: usize) -> Self::Cache;
 
-    /// Create a cache with custom configuration
+    /// Creates a cache with custom configuration.
     fn create_with_config(config: CacheConfig) -> Self::Cache;
 }
 
-/// Configuration for cache creation
+/// Configuration for cache creation.
+///
+/// Used with [`CacheFactory::create_with_config`] to customize cache behavior.
+///
+/// # Fields
+///
+/// | Field | Type | Default | Description |
+/// |-------|------|---------|-------------|
+/// | `capacity` | `usize` | 1000 | Maximum number of entries |
+/// | `enable_stats` | `bool` | false | Enable hit/miss tracking |
+/// | `prealloc_memory` | `bool` | true | Pre-allocate memory for capacity |
+/// | `thread_safe` | `bool` | false | Use internal synchronization |
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::CacheConfig;
+///
+/// // Use defaults
+/// let config = CacheConfig::default();
+/// assert_eq!(config.capacity, 1000);
+/// assert!(!config.enable_stats);
+///
+/// // Custom configuration
+/// let config = CacheConfig {
+///     capacity: 5000,
+///     enable_stats: true,
+///     ..Default::default()
+/// };
+/// assert_eq!(config.capacity, 5000);
+/// assert!(config.enable_stats);
+/// assert!(config.prealloc_memory);  // from default
+/// ```
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
+    /// Maximum number of entries the cache can hold.
     pub capacity: usize,
+
+    /// Enable hit/miss statistics tracking.
+    ///
+    /// When enabled, the cache tracks hit rate, miss rate, and other metrics.
+    /// Has a small performance overhead.
     pub enable_stats: bool,
+
+    /// Pre-allocate memory for the full capacity.
+    ///
+    /// When true, memory is allocated upfront to avoid reallocations.
+    /// When false, memory grows as needed (may cause latency spikes).
     pub prealloc_memory: bool,
+
+    /// Use internal synchronization for thread safety.
+    ///
+    /// When true, the cache uses internal locks for thread-safe operations.
+    /// When false, external synchronization (e.g., `Arc<RwLock<Cache>>`) is required.
     pub thread_safe: bool,
 }
 
 impl Default for CacheConfig {
+    /// Creates a default configuration.
+    ///
+    /// Defaults:
+    /// - `capacity`: 1000
+    /// - `enable_stats`: false
+    /// - `prealloc_memory`: true
+    /// - `thread_safe`: false
     fn default() -> Self {
         Self {
             capacity: 1000,
@@ -442,15 +1345,48 @@ impl Default for CacheConfig {
     }
 }
 
-/// Extension trait for async cache operations
-/// Note: Will be implemented in Phase 2 when async-trait dependency is added
+/// Extension trait for async cache operations.
+///
+/// This trait is a placeholder for future async cache support. It will be
+/// fully implemented in Phase 2 when the `async-trait` dependency is added.
+///
+/// Currently, all methods return `false` indicating async operations are
+/// not supported. Implementations can override these to indicate support.
+///
+/// # Future API (Phase 2)
+///
+/// ```ignore
+/// // Future async methods (not yet implemented)
+/// async fn async_get(&self, key: &K) -> Option<&V>;
+/// async fn async_insert(&mut self, key: K, value: V) -> Option<V>;
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use cachekit::traits::AsyncCacheFuture;
+///
+/// struct MyCache;
+///
+/// impl AsyncCacheFuture<u64, String> for MyCache {
+///     // Use defaults (no async support)
+/// }
+///
+/// let cache = MyCache;
+/// assert!(!cache.supports_async_get());
+/// assert!(!cache.supports_async_insert());
+/// ```
 pub trait AsyncCacheFuture<K, V>: Send + Sync {
-    /// Placeholder for future async get operation
+    /// Returns whether this cache supports async get operations.
+    ///
+    /// Default returns `false`. Override to indicate async support.
     fn supports_async_get(&self) -> bool {
         false
     }
 
-    /// Placeholder for future async insert operation
+    /// Returns whether this cache supports async insert operations.
+    ///
+    /// Default returns `false`. Override to indicate async support.
     fn supports_async_insert(&self) -> bool {
         false
     }


### PR DESCRIPTION
# PR: Complete Documentation for Cache Policy Modules

## Summary

This PR adds comprehensive documentation to the cache policy modules in `src/policy/`. Each module now includes:

- Architecture diagrams in module-level documentation
- Docstrings with examples for all public structs and methods
- Brief docstrings for private methods (summary, preconditions, complexity)
- Verified doctests that compile and pass

## Files Changed

### `src/policy/lru_k.rs`
**LRU-K (Least Recently Used - K) Cache Implementation**

| Item | Documentation Added |
|------|---------------------|
| Module | Architecture diagram, eviction policy, scan resistance explanation, K-distance calculation |
| `LrukCache<K, V>` | Type parameters, 2 examples (basic usage, scan resistance) |
| `new()` | Example with default K=2 |
| `with_k()` | Example with custom K, clamping behavior |
| `CoreCache` impl | Example for insert/get/contains/len/capacity/clear |
| `MutableCache` impl | Example for remove |
| `LrukCacheTrait` impl | Example for access_count/k_distance/peek_lru_k/pop_lru_k |
| Private methods | 7 docstrings with complexity notes |

**Doctests:** 7 passing, 1 ignored

---

### `src/policy/lfu.rs`
**LFU (Least Frequently Used) Cache Implementation**

| Item | Documentation Added |
|------|---------------------|
| Module | Architecture diagram, LFU vs LRU comparison, eviction flow, frequency lifecycle |
| `LfuCache<K, V>` | Type parameters, example with frequency tracking and eviction |
| `LFUHandleCache<H, V>` | Type parameters, example with u64 handles |
| `new()` | Examples for both cache types |
| `insert_batch()` | Examples for both cache types |
| `remove_batch()` | Examples for both cache types |
| `touch_batch()` | Examples for both cache types |
| `CoreCache` impl | Examples for both cache types |
| `MutableCache` impl | Examples for both cache types |
| `LfuCacheTrait` impl | Examples for both cache types |
| `metrics_snapshot()` | Docstrings for both cache types |
| Private methods | 2 docstrings (evict_min_freq for each type) |

**Doctests:** 16 passing, 2 ignored

---

### `src/policy/heap_lfu.rs`
**Heap-Based LFU Cache Implementation**

| Item | Documentation Added |
|------|---------------------|
| Module | Architecture diagram, stale entry handling, Standard vs Heap LFU comparison |
| `HeapLfuCache<K, V>` | Type parameters, example with O(log n) operations, stale entry explanation |
| `new()` | Example with capacity/len/is_empty |
| `capacity()` | Example |
| `len()` | Example |
| `is_empty()` | Example |
| `contains()` | Example |
| `frequency()` | Example with get incrementing frequency |
| `clear()` | Example |
| `CoreCache` impl | Example for insert/get/contains/len/capacity |
| `MutableCache` impl | Example for remove |
| `LfuCacheTrait` impl | Example for frequency/peek_lfu/pop_lfu/increment/reset |
| Private methods | 4 docstrings with complexity notes |

**Doctests:** 11 passing, 1 ignored

---

## Documentation Style

### Public Items
- Brief summary of behavior
- Type parameters documented
- One or more compile-ready examples
- Notes on complexity where relevant

### Private Methods
- Brief summary of what they do
- Notes on invariants or preconditions (if non-obvious)
- Complexity notes (if relevant to design decisions)

### Example Format
```rust
/// Brief summary of the method.
///
/// # Example
///
/// ```
/// use cachekit::policy::module::Type;
/// use cachekit::traits::Trait;
///
/// let mut cache = Type::new(10);
/// // ... example code ...
/// assert!(condition);
/// ```
```

## Test Results

All doctests pass:

```
policy::lru_k:    7 passed, 1 ignored
policy::lfu:     16 passed, 2 ignored  
policy::heap_lfu: 11 passed, 1 ignored
─────────────────────────────────────
Total:           34 passed, 4 ignored
```

No linter errors introduced.

## Checklist

- [x] Architecture diagrams added to module docs
- [x] Public struct docstrings with examples
- [x] Public method docstrings with examples
- [x] Private method docstrings (no examples)
- [x] Trait implementation docstrings with examples
- [x] All doctests compile and pass
- [x] No linter errors
