### PR TITLE
Fix/various bugs found

### DIFF
--- a/src/ds/clock_ring.rs
+++ b/src/ds/clock_ring.rs
@@ -11,7 +11,7 @@
 //! │                           ClockRing<K, V>                                 │
 //! │                                                                           │
 //! │   ┌─────────────────────────────┐   ┌─────────────────────────────────┐   │
-//! │   │  index: HashMap<K, usize>   │   │  slots: Vec<Option<Entry>>      │   │
+//! │   │  index: FxHashMap<K, usize> │   │  slots: Vec<Option<Entry>>      │   │
 //! │   │                             │   │                                 │   │
 //! │   │  ┌───────────┬──────────┐   │   │   ┌─────┬─────┬─────┬─────┐     │   │
 //! │   │  │    Key    │  Index   │   │   │   │  0  │  1  │  2  │  3  │     │   │
@@ -193,6 +193,13 @@ struct Entry<K, V> {
 /// Provides O(1) amortized insertion with automatic eviction of unreferenced
 /// entries. Accessed entries receive a "second chance" via a reference bit.
 ///
+/// Lookup methods ([`get`](Self::get), [`peek`](Self::peek),
+/// [`contains`](Self::contains), etc.) accept any borrowed form of the key
+/// via [`Borrow`], so a `ClockRing<String, V>` can be
+/// queried with `&str`.
+///
+/// Implements [`Clone`], [`Debug`], and [`Extend`]`<(K, V)>`.
+///
 /// # Type Parameters
 ///
 /// - `K`: Key type, must be `Eq + Hash + Clone`
@@ -251,7 +258,8 @@ pub struct ClockRing<K, V> {
 ///
 /// Provides the same functionality as [`ClockRing`] but safe for concurrent
 /// access. Uses closure-based value access since references cannot outlive
-/// lock guards.
+/// lock guards. Lookup methods accept any borrowed form of the key via
+/// [`Borrow`].
 ///
 /// # Example
 ///

--- a/src/ds/ghost_list.rs
+++ b/src/ds/ghost_list.rs
@@ -505,6 +505,13 @@ where
         true
     }
 
+    /// Removes and returns the LRU (least recently used) key.
+    pub fn evict_lru(&mut self) -> Option<K> {
+        let key = self.list.pop_back()?;
+        self.index.remove(&key);
+        Some(key)
+    }
+
     /// Removes a batch of keys; returns number of keys actually removed.
     ///
     /// # Example

--- a/src/ds/mod.rs
+++ b/src/ds/mod.rs
@@ -8,9 +8,9 @@ pub mod lazy_heap;
 pub mod shard;
 pub mod slot_arena;
 
-pub use clock_ring::ClockRing;
 #[cfg(feature = "concurrency")]
 pub use clock_ring::ConcurrentClockRing;
+pub use clock_ring::{ClockRing, IntoIter, Iter, IterMut, Keys, Values, ValuesMut};
 pub use fixed_history::FixedHistory;
 pub use frequency_buckets::{
     DEFAULT_BUCKET_PREALLOC, FrequencyBucketEntryMeta, FrequencyBuckets, FrequencyBucketsHandle,

--- a/src/policy/clock.rs
+++ b/src/policy/clock.rs
@@ -162,7 +162,7 @@ where
     #[inline]
     pub fn new(capacity: usize) -> Self {
         Self {
-            ring: ClockRing::new(capacity.max(1)),
+            ring: ClockRing::new(capacity),
         }
     }
 
@@ -230,12 +230,12 @@ where
     /// ```
     #[inline]
     fn insert(&mut self, key: K, value: V) -> Option<V> {
-        // Check if key exists first (without consuming value)
+        if self.ring.capacity() == 0 {
+            return None;
+        }
         if self.ring.contains(&key) {
-            // Key exists - update returns old value
             return self.ring.update(&key, value);
         }
-        // New key - insert (may evict, but we discard evicted entry)
         let _ = self.ring.insert(key, value);
         None
     }
@@ -482,7 +482,7 @@ mod tests {
         #[test]
         fn test_zero_capacity_clamped() {
             let cache: ClockCache<i32, i32> = ClockCache::new(0);
-            assert_eq!(cache.capacity(), 1); // Clamped to 1
+            assert_eq!(cache.capacity(), 0);
         }
 
         #[test]

--- a/src/policy/clock_pro.rs
+++ b/src/policy/clock_pro.rs
@@ -214,9 +214,6 @@ where
     /// periodic re-access patterns.
     #[inline]
     pub fn with_ghost_capacity(capacity: usize, ghost_capacity: usize) -> Self {
-        let capacity = capacity.max(1);
-        let ghost_capacity = ghost_capacity.max(1);
-
         let mut entries = Vec::with_capacity(capacity);
         entries.resize_with(capacity, || None);
 

--- a/src/policy/mfu.rs
+++ b/src/policy/mfu.rs
@@ -826,4 +826,20 @@ mod tests {
         assert_eq!(cache.len(), 3);
         assert_eq!(cache.frequencies.len(), 3);
     }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    #[test]
+    fn zero_capacity_insert_returns_none() {
+        let mut cache: MfuCore<&str, i32> = MfuCore::new(0);
+
+        let result = cache.insert("new_key", 42);
+
+        assert_eq!(
+            result, None,
+            "MfuCore::insert at capacity=0 should return None for a new key"
+        );
+    }
 }

--- a/src/policy/mfu.rs
+++ b/src/policy/mfu.rs
@@ -217,7 +217,7 @@ where
     /// Inserts a key-value pair, evicting the most frequently used entry if at capacity.
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         if self.capacity == 0 {
-            return Some(value);
+            return None;
         }
 
         // Update or insert
@@ -431,7 +431,7 @@ where
 {
     fn insert(&mut self, key: K, value: V) -> Option<V> {
         if self.capacity == 0 {
-            return Some(value);
+            return None;
         }
 
         // Update or insert

--- a/src/policy/mru.rs
+++ b/src/policy/mru.rs
@@ -1003,4 +1003,47 @@ mod tests {
         assert!(cache.contains(&3));
         assert!(cache.contains(&4));
     }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    #[test]
+    fn zero_capacity_rejects_inserts() {
+        let mut cache: MruCore<&str, i32> = MruCore::new(0);
+        assert_eq!(cache.capacity(), 0);
+
+        cache.insert("key", 42);
+
+        assert_eq!(
+            cache.len(),
+            0,
+            "MruCore with capacity=0 should reject inserts"
+        );
+    }
+
+    #[test]
+    fn trait_insert_returns_old_value() {
+        let mut cache: MruCore<&str, i32> = MruCore::new(10);
+
+        let first = CoreCache::insert(&mut cache, "key", 1);
+        assert_eq!(first, None);
+
+        let second = CoreCache::insert(&mut cache, "key", 2);
+        assert_eq!(
+            second,
+            Some(1),
+            "Second insert via trait should return old value"
+        );
+    }
+
+    #[test]
+    fn inherent_insert_updates_value() {
+        let mut cache: MruCore<&str, i32> = MruCore::new(10);
+
+        cache.insert("key", 1);
+        cache.insert("key", 2);
+
+        assert_eq!(cache.get(&"key"), Some(&2));
+    }
 }

--- a/src/policy/mru.rs
+++ b/src/policy/mru.rs
@@ -370,13 +370,15 @@ where
     /// assert_eq!(cache.len(), 1);  // Still 1 entry
     /// ```
     #[inline]
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if self.capacity == 0 {
+            return None;
+        }
+
         // Check for existing key - update in place
         if let Some(&node_ptr) = self.map.get(&key) {
-            unsafe {
-                (*node_ptr.as_ptr()).value = value;
-            }
-            return;
+            let old = unsafe { std::mem::replace(&mut (*node_ptr.as_ptr()).value, value) };
+            return Some(old);
         }
 
         // Evict BEFORE inserting to ensure space is available
@@ -396,6 +398,7 @@ where
 
         #[cfg(debug_assertions)]
         self.validate_invariants();
+        None
     }
 
     /// Evicts entries until there is room for a new entry.
@@ -616,18 +619,7 @@ where
 {
     #[inline]
     fn insert(&mut self, key: K, value: V) -> Option<V> {
-        // Check if key exists - update in place
-        if let Some(&node_ptr) = self.map.get(&key) {
-            let old = unsafe {
-                let node = &mut *node_ptr.as_ptr();
-                std::mem::replace(&mut node.value, value)
-            };
-            return Some(old);
-        }
-
-        // New insert
-        MruCore::insert(self, key, value);
-        None
+        MruCore::insert(self, key, value)
     }
 
     #[inline]

--- a/src/policy/nru.rs
+++ b/src/policy/nru.rs
@@ -248,7 +248,6 @@ where
     /// ```
     #[inline]
     pub fn new(capacity: usize) -> Self {
-        let capacity = capacity.max(1);
         Self {
             map: FxHashMap::default(),
             keys: Vec::with_capacity(capacity),
@@ -371,6 +370,9 @@ where
     /// ```
     #[inline]
     fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if self.capacity == 0 {
+            return None;
+        }
         // Check if key already exists
         if let Some(entry) = self.map.get_mut(&key) {
             // Update existing entry
@@ -625,10 +627,9 @@ mod tests {
     #[test]
     fn test_zero_capacity() {
         let mut cache = NruCache::new(0);
-        // Should default to capacity of 1
-        assert!(cache.capacity() >= 1);
+        assert_eq!(cache.capacity(), 0);
 
         cache.insert(1, 100);
-        assert!(cache.contains(&1));
+        assert!(!cache.contains(&1));
     }
 }

--- a/src/policy/slru.rs
+++ b/src/policy/slru.rs
@@ -1572,4 +1572,47 @@ mod tests {
 
         assert_eq!(cache.len(), 5);
     }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    #[test]
+    fn zero_capacity_rejects_inserts() {
+        let mut cache: SlruCore<&str, i32> = SlruCore::new(0, 0.25);
+        assert_eq!(cache.capacity(), 0);
+
+        cache.insert("key", 42);
+
+        assert_eq!(
+            cache.len(),
+            0,
+            "SlruCore with capacity=0 should reject inserts"
+        );
+    }
+
+    #[test]
+    fn trait_insert_returns_old_value() {
+        let mut cache: SlruCore<&str, i32> = SlruCore::new(10, 0.25);
+
+        let first = CoreCache::insert(&mut cache, "key", 1);
+        assert_eq!(first, None);
+
+        let second = CoreCache::insert(&mut cache, "key", 2);
+        assert_eq!(
+            second,
+            Some(1),
+            "Second insert via trait should return old value"
+        );
+    }
+
+    #[test]
+    fn inherent_insert_updates_value() {
+        let mut cache: SlruCore<&str, i32> = SlruCore::new(10, 0.25);
+
+        cache.insert("key", 1);
+        cache.insert("key", 2);
+
+        assert_eq!(cache.get(&"key"), Some(&2));
+    }
 }

--- a/src/policy/two_q.rs
+++ b/src/policy/two_q.rs
@@ -1778,4 +1778,43 @@ mod tests {
             );
         }
     }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    #[test]
+    fn zero_capacity_rejects_inserts() {
+        let mut cache: TwoQCore<&str, i32> = TwoQCore::new(0, 0.25);
+        assert_eq!(cache.capacity(), 0);
+
+        cache.insert("key", 42);
+
+        assert_eq!(
+            cache.len(),
+            0,
+            "TwoQCore with capacity=0 should reject inserts"
+        );
+    }
+
+    #[test]
+    fn trait_insert_returns_old_value() {
+        let mut cache: TwoQCore<&str, i32> = TwoQCore::new(10, 0.25);
+
+        let first = CoreCache::insert(&mut cache, "key", 1);
+        assert_eq!(first, None, "First insert of new key should return None");
+
+        let second = CoreCache::insert(&mut cache, "key", 2);
+        assert_eq!(second, Some(1), "Second insert should return old value");
+    }
+
+    #[test]
+    fn inherent_insert_updates_value() {
+        let mut cache: TwoQCore<&str, i32> = TwoQCore::new(10, 0.25);
+
+        cache.insert("key", 1);
+        cache.insert("key", 2);
+
+        assert_eq!(cache.get(&"key"), Some(&2), "Value should be updated to 2");
+    }
 }

--- a/src/policy/two_q.rs
+++ b/src/policy/two_q.rs
@@ -712,13 +712,15 @@ where
     /// assert_eq!(cache.len(), 1);  // Still 1 entry
     /// ```
     #[inline]
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if self.protected_cap == 0 {
+            return None;
+        }
+
         // Check for existing key - update in place
         if let Some(&node_ptr) = self.map.get(&key) {
-            unsafe {
-                (*node_ptr.as_ptr()).value = value;
-            }
-            return;
+            let old = unsafe { std::mem::replace(&mut (*node_ptr.as_ptr()).value, value) };
+            return Some(old);
         }
 
         // Evict BEFORE inserting to ensure space is available
@@ -736,6 +738,7 @@ where
 
         self.map.insert(key, node_ptr);
         self.attach_probation_head(node_ptr);
+        None
     }
 
     /// Evicts entries until there is room for a new entry.
@@ -929,18 +932,7 @@ where
 {
     #[inline]
     fn insert(&mut self, key: K, value: V) -> Option<V> {
-        // Check if key exists - update in place
-        if let Some(&node_ptr) = self.map.get(&key) {
-            let old = unsafe {
-                let node = &mut *node_ptr.as_ptr();
-                std::mem::replace(&mut node.value, value)
-            };
-            return Some(old);
-        }
-
-        // New insert
-        TwoQCore::insert(self, key, value);
-        None
+        TwoQCore::insert(self, key, value)
     }
 
     #[inline]

--- a/src/store/weight.rs
+++ b/src/store/weight.rs
@@ -850,4 +850,63 @@ mod tests {
         assert_eq!(store.remove(&"k1"), Some(value));
         assert_eq!(store.total_weight(), 0);
     }
+
+    // ==============================================
+    // Regression Tests
+    // ==============================================
+
+    #[cfg(feature = "concurrency")]
+    #[test]
+    fn concurrent_weight_store_metrics_track_inserts() {
+        let store: ConcurrentWeightStore<&str, String, _> =
+            ConcurrentWeightStore::with_capacity(100, 100_000, weight_by_len);
+
+        store.try_insert("k1", Arc::new("v1".into())).unwrap();
+        store.try_insert("k2", Arc::new("v2".into())).unwrap();
+        store.try_insert("k3", Arc::new("v3".into())).unwrap();
+
+        let metrics = store.metrics();
+        assert_eq!(metrics.inserts, 3, "metrics should track inserts");
+    }
+
+    #[cfg(feature = "concurrency")]
+    #[test]
+    fn concurrent_weight_store_metrics_track_updates() {
+        let store: ConcurrentWeightStore<&str, String, _> =
+            ConcurrentWeightStore::with_capacity(100, 100_000, weight_by_len);
+
+        store.try_insert("k1", Arc::new("v1".into())).unwrap();
+        store.try_insert("k1", Arc::new("updated".into())).unwrap();
+
+        let metrics = store.metrics();
+        assert_eq!(metrics.updates, 1, "metrics should track updates");
+    }
+
+    #[cfg(feature = "concurrency")]
+    #[test]
+    fn concurrent_weight_store_metrics_track_removes() {
+        let store: ConcurrentWeightStore<&str, String, _> =
+            ConcurrentWeightStore::with_capacity(100, 100_000, weight_by_len);
+
+        store.try_insert("k1", Arc::new("v1".into())).unwrap();
+        store.remove(&"k1");
+
+        let metrics = store.metrics();
+        assert_eq!(metrics.removes, 1, "metrics should track removes");
+    }
+
+    #[cfg(feature = "concurrency")]
+    #[test]
+    fn concurrent_weight_store_metrics_track_hits_misses() {
+        let store: ConcurrentWeightStore<&str, String, _> =
+            ConcurrentWeightStore::with_capacity(100, 100_000, weight_by_len);
+
+        store.try_insert("k1", Arc::new("v1".into())).unwrap();
+        let _ = store.get(&"k1");
+        let _ = store.get(&"missing");
+
+        let metrics = store.metrics();
+        assert_eq!(metrics.hits, 1);
+        assert_eq!(metrics.misses, 1);
+    }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,11 @@ This directory contains all integration and regression tests for cachekit.
 - **`lfu_concurrency.rs`** - LFU concurrent access tests
 - **`lru_concurrency.rs`** - LRU concurrent access tests
 - **`lru_k_concurrency.rs`** - LRU-K concurrent access tests
+- **`slab_concurrency.rs`** - ConcurrentSlabStore race condition and atomicity tests
+
+### Invariant Tests
+
+- **`policy_invariants.rs`** - Cross-policy behavioral consistency (e.g. capacity-0 semantics)
 
 ### Integration Tests
 

--- a/tests/policy_invariants.rs
+++ b/tests/policy_invariants.rs
@@ -1,0 +1,82 @@
+// ==============================================
+// CROSS-POLICY INVARIANT TESTS (integration)
+// ==============================================
+//
+// Tests that verify library-wide behavioral consistency across all cache
+// policies. These span multiple modules and belong here rather than in any
+// single source file.
+
+// ==============================================
+// Capacity-0 Behavior
+// ==============================================
+//
+// Some policies silently coerce capacity=0 to capacity=1 via .max(1) in
+// their constructor, which is inconsistent with the rest of the library.
+
+#[cfg(feature = "policy-clock")]
+mod clock_zero_capacity {
+    use cachekit::policy::clock::ClockCache;
+    use cachekit::traits::ReadOnlyCache;
+
+    #[test]
+    fn capacity_zero_is_honored() {
+        let cache: ClockCache<&str, i32> = ClockCache::new(0);
+
+        assert_eq!(
+            cache.capacity(),
+            0,
+            "ClockCache::new(0) should honor capacity=0, not coerce to {}",
+            cache.capacity()
+        );
+    }
+}
+
+#[cfg(feature = "policy-clock-pro")]
+mod clock_pro_zero_capacity {
+    use cachekit::policy::clock_pro::ClockProCache;
+    use cachekit::traits::ReadOnlyCache;
+
+    #[test]
+    fn capacity_zero_is_honored() {
+        let cache: ClockProCache<&str, i32> = ClockProCache::new(0);
+
+        assert_eq!(
+            cache.capacity(),
+            0,
+            "ClockProCache::new(0) should honor capacity=0, not coerce to {}",
+            cache.capacity()
+        );
+    }
+
+    #[test]
+    fn capacity_zero_rejects_inserts() {
+        use cachekit::traits::CoreCache;
+
+        let mut cache: ClockProCache<&str, i32> = ClockProCache::new(0);
+        cache.insert("key", 42);
+
+        assert_eq!(
+            cache.len(),
+            0,
+            "ClockProCache with capacity=0 should reject inserts"
+        );
+    }
+}
+
+#[cfg(feature = "policy-nru")]
+mod nru_zero_capacity {
+    use cachekit::policy::nru::NruCache;
+    use cachekit::traits::ReadOnlyCache;
+
+    #[test]
+    fn capacity_zero_is_honored() {
+        let cache: NruCache<&str, i32> = NruCache::new(0);
+
+        assert_eq!(
+            cache.capacity(),
+            0,
+            "NruCache::new(0) should honor capacity=0, not coerce to {}",
+            cache.capacity()
+        );
+    }
+}

--- a/tests/slab_concurrency.rs
+++ b/tests/slab_concurrency.rs
@@ -1,0 +1,192 @@
+// ==============================================
+// SLAB STORE CONCURRENCY TESTS (integration)
+// ==============================================
+//
+// Tests for race conditions and atomicity issues in ConcurrentSlabStore.
+// These require multi-threaded execution and cannot live inline.
+
+#![cfg(feature = "concurrency")]
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use cachekit::store::slab::ConcurrentSlabStore;
+use cachekit::store::traits::{ConcurrentStore, ConcurrentStoreRead};
+
+// ==============================================
+// TOCTOU Race: Update Path Data Corruption
+// ==============================================
+//
+// try_insert's update path drops the index read lock before acquiring the
+// entries write lock. A concurrent remove + reinsert can recycle the slot,
+// causing the original thread to overwrite an unrelated key's value.
+
+mod toctou_update {
+    use super::*;
+
+    #[test]
+    fn concurrent_update_after_remove_preserves_invariants() {
+        let iterations = 500;
+
+        for _ in 0..iterations {
+            let store: Arc<ConcurrentSlabStore<u64, String>> =
+                Arc::new(ConcurrentSlabStore::new(100));
+
+            store
+                .try_insert(1, Arc::new("key1_original".into()))
+                .unwrap();
+            store
+                .try_insert(2, Arc::new("key2_original".into()))
+                .unwrap();
+
+            let barrier = Arc::new(Barrier::new(3));
+
+            let store_a = store.clone();
+            let barrier_a = barrier.clone();
+            let t_a = thread::spawn(move || {
+                barrier_a.wait();
+                let _ = store_a.try_insert(1, Arc::new("key1_updated".into()));
+            });
+
+            let store_b = store.clone();
+            let barrier_b = barrier.clone();
+            let t_b = thread::spawn(move || {
+                barrier_b.wait();
+                let _ = store_b.remove(&1);
+            });
+
+            let store_c = store.clone();
+            let barrier_c = barrier.clone();
+            let t_c = thread::spawn(move || {
+                barrier_c.wait();
+                let _ = store_c.try_insert(3, Arc::new("key3_value".into()));
+            });
+
+            t_a.join().unwrap();
+            t_b.join().unwrap();
+            t_c.join().unwrap();
+
+            if let Some(val) = store.get(&2) {
+                assert_eq!(
+                    *val, "key2_original",
+                    "key 2 was corrupted by a concurrent update to a recycled slot"
+                );
+            }
+
+            if let Some(val) = store.get(&3) {
+                assert_eq!(
+                    *val, "key3_value",
+                    "key 3 was corrupted by a concurrent update to a recycled slot"
+                );
+            }
+        }
+    }
+}
+
+// ==============================================
+// TOCTOU Race: Capacity Overshoot
+// ==============================================
+//
+// The capacity check and actual insert use separate locks, allowing multiple
+// threads to pass the check simultaneously and exceed capacity.
+
+mod capacity_overshoot {
+    use super::*;
+
+    #[test]
+    fn concurrent_inserts_respect_capacity() {
+        let capacity = 10;
+        let num_threads = 20;
+        let inserts_per_thread = 5;
+
+        for _ in 0..200 {
+            let store: Arc<ConcurrentSlabStore<u64, u64>> =
+                Arc::new(ConcurrentSlabStore::new(capacity));
+            let barrier = Arc::new(Barrier::new(num_threads));
+
+            let handles: Vec<_> = (0..num_threads)
+                .map(|tid| {
+                    let store = store.clone();
+                    let barrier = barrier.clone();
+                    thread::spawn(move || {
+                        barrier.wait();
+                        for i in 0..inserts_per_thread {
+                            let key = (tid * inserts_per_thread + i) as u64;
+                            let _ = store.try_insert(key, Arc::new(key));
+                        }
+                    })
+                })
+                .collect();
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            assert!(
+                store.len() <= capacity,
+                "ConcurrentSlabStore len ({}) exceeds capacity ({})",
+                store.len(),
+                capacity,
+            );
+        }
+    }
+}
+
+// ==============================================
+// Non-Atomic clear()
+// ==============================================
+//
+// clear() acquires 3 separate write locks sequentially. Between clearing
+// entries and clearing the index, concurrent get() calls find keys in the
+// index but miss in the empty entries vec.
+
+mod nonatomic_clear {
+    use super::*;
+
+    #[test]
+    fn clear_concurrent_with_get_is_consistent() {
+        let store: Arc<ConcurrentSlabStore<u64, u64>> = Arc::new(ConcurrentSlabStore::new(1000));
+        let stop = Arc::new(AtomicBool::new(false));
+        let false_misses = Arc::new(AtomicUsize::new(0));
+
+        for i in 0..1000u64 {
+            store.try_insert(i, Arc::new(i)).unwrap();
+        }
+
+        let store_r = store.clone();
+        let stop_r = stop.clone();
+        let false_misses_r = false_misses.clone();
+        let reader = thread::spawn(move || {
+            while !stop_r.load(Ordering::Relaxed) {
+                for i in 0..100u64 {
+                    if store_r.contains(&i) && store_r.get(&i).is_none() {
+                        false_misses_r.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        });
+
+        let store_w = store.clone();
+        let stop_w = stop.clone();
+        let writer = thread::spawn(move || {
+            for _ in 0..500 {
+                store_w.clear();
+                for i in 0..100u64 {
+                    let _ = store_w.try_insert(i, Arc::new(i));
+                }
+            }
+            stop_w.store(true, Ordering::Relaxed);
+        });
+
+        reader.join().unwrap();
+        writer.join().unwrap();
+
+        assert_eq!(
+            false_misses.load(Ordering::Relaxed),
+            0,
+            "contains() returned true but get() returned None — \
+             clear() is not atomic across its internal locks"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This branch fixes several correctness bugs discovered across cache policies and concurrent stores, and adds regression tests to prevent recurrence.

### Bug Fixes

- **ConcurrentSlabStore TOCTOU race conditions** — The old design used three separate `RwLock`s (for index, entries, and free list), creating time-of-check-to-time-of-use windows that could cause data corruption on concurrent update-after-remove, capacity overshoot under parallel inserts, and half-cleared state visible to readers during `clear()`. Refactored into a single `SlabInner` struct behind one `RwLock` to ensure atomicity across all mutations.

- **ARC ghost-list directory leak** — The Case 4 (complete miss) path was not properly pruning ghost lists B1/B2, violating the ARC paper's invariant that directory size (T1+T2+B1+B2) ≤ 2×capacity. Fixed to match the paper's eviction logic and added `GhostList::evict_lru()` to support it.

- **Capacity-0 coercion in Clock, ClockPro, NRU** — These policies silently coerced `capacity=0` to `capacity=1` via `.max(1)` in their constructors, inconsistent with the rest of the library. Now they honor `capacity=0` and reject inserts gracefully.

- **MFU insert return-value bug** — `MfuCore::insert` at `capacity=0` returned `Some(value)` (echoing the value back) instead of `None`. Fixed to return `None` for rejected inserts.

- **MRU / SLRU / TwoQ `CoreCache::insert` inconsistency** — The `CoreCache` trait impl duplicated update-in-place logic that diverged from each type's inherent `insert` method. Unified by having the trait impl delegate directly to the inherent method. The inherent `insert` now returns `Option<V>` (old value on update, `None` on fresh insert).

- **ConcurrentWeightStore missing metrics** — `try_insert` and `remove` delegated to the inner store without updating the external metrics counters for inserts, updates, and removes.

### Enhancements

- **ClockRing iterators** — Added `Iter`, `IterMut`, `IntoIter`, `Keys`, `Values`, `ValuesMut` and `IntoIterator` impl for `ClockRing`.
- **ClockRing documentation** — Improved module docs with rustdoc intra-doc links and updated the operations table.

### Tests Added

- `tests/slab_concurrency.rs` — Integration tests for TOCTOU update corruption, capacity overshoot, and atomic `clear()` under concurrency.
- `tests/policy_invariants.rs` — Cross-policy invariant tests for capacity-0 semantics (Clock, ClockPro, NRU).
- Per-policy unit regression tests for capacity-0 behavior, insert return values, and ARC ghost-list bounds.
- `ConcurrentWeightStore` metrics tracking tests for inserts, updates, removes, hits, and misses.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test addition or modification

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests for my changes
- [x] All new and existing tests pass (`cargo test`)
- [x] I have updated the documentation as needed
