### PR TITLE
Refactor `ClockRing` insert logic to optimize slot usage and prevent …

### DIFF
--- a/src/policy/clock.rs
+++ b/src/policy/clock.rs
@@ -304,26 +304,20 @@ where
     }
 }
 
-// SAFETY: ClockCache can be sent between threads if K and V are Send.
-unsafe impl<K, V> Send for ClockCache<K, V>
-where
-    K: Clone + Eq + Hash + Send,
-    V: Send,
-{
-}
-
-// SAFETY: ClockCache can be shared between threads if K and V are Sync.
-unsafe impl<K, V> Sync for ClockCache<K, V>
-where
-    K: Clone + Eq + Hash + Sync,
-    V: Sync,
-{
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::traits::MutableCache;
+
+    #[allow(dead_code)]
+    const _: () = {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        fn check() {
+            assert_send::<ClockCache<String, i32>>();
+            assert_sync::<ClockCache<String, i32>>();
+        }
+    };
 
     mod basic_operations {
         use super::*;


### PR DESCRIPTION
…unnecessary evictions

- Enhanced the `insert` method to utilize empty slots when available, ensuring that entries are not evicted when the cache has free space.
- Implemented a two-pass CLOCK sweep for eviction, maintaining reference bits for entries to improve eviction accuracy.
- Added regression tests to verify that inserts do not evict existing entries when there are available slots, ensuring correct behavior under various scenarios.
- Updated documentation and tests to reflect these changes, improving clarity and usability of the `ClockRing` API.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

<!-- Describe how you tested your changes -->

- [x] Unit tests


**Test environment:**
- OS:
- Rust version:

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's coding standards
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have added tests for my changes
- [x] All new and existing tests pass (`cargo test`)
- [x] I have updated the documentation as needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
