### PR TITLE
Harden dependency policy with strict cargo-deny and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Dependency policy checks across all execution paths
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny
+      - name: Run cargo-deny checks
+        run: cargo deny check all
+
   # Benchmarks (only on the main branch)
   bench:
     name: Benchmarks

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -12,21 +12,28 @@ permissions:
   contents: read
 
 jobs:
-  security-audit:
-    name: Security Audit
+  # Weekly dependency policy drift check.
+  dependency-policy:
+    name: Dependency Policy (cargo-deny)
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  latest-stable-smoke:
-    name: Latest Stable Smoke
-    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - name: Build and test
-        run: cargo test --all-features --all-targets
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny
+      - name: Check advisories, bans, licenses, and sources
+        run: cargo deny check all
+
+  # Weekly toolchain drift check against latest stable.
+  latest-stable-smoke:
+    name: Latest Stable Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - name: Build and test workspace
+        run: cargo test --workspace --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ parking_lot = { version = "0.12", optional = true }
 rustc-hash = "2.1"
 
 [dev-dependencies]
-bench-support = { path = "bench-support" }
+bench-support = { path = "bench-support", version = "0.1.0" }
 criterion = "0.8"
 dhat = "0.3"
 lru = "0.16"

--- a/bench-support/Cargo.toml
+++ b/bench-support/Cargo.toml
@@ -9,7 +9,7 @@ name = "render_docs"
 path = "src/bin/render_docs.rs"
 
 [dependencies]
-cachekit = { path = "..", features = ["policy-all"] }
+cachekit = { path = "..", version = "0.4.0", features = ["policy-all"] }
 criterion = "0.8"
 rand = "0.10"
 rand_distr = "0.6"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,57 @@
+[licenses]
+confidence-threshold = 0.93
+unused-allowed-license = "warn"
+include-build = true
+include-dev = true
+allow = [
+    "MIT",
+    "Apache-2.0",
+]
+
+[licenses.private]
+ignore = true
+
+[[licenses.exceptions]]
+crate = "unicode-ident"
+allow = ["Unicode-3.0"]
+
+[[licenses.exceptions]]
+crate = "foldhash"
+allow = ["Zlib"]
+
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+exclude-dev = false
+
+[advisories]
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = [
+    "https://github.com/rust-lang/crates.io-index",
+]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
## Summary
- Add a new top-level `deny.toml` with strict policy checks across advisories, bans, licenses, and sources.
- Enforce dependency policy in PR/push CI via a new `cargo-deny` job running `cargo deny check all`.
- Refactor `maintenance.yml` to run weekly dependency-policy drift checks with `cargo-deny` and keep a latest-stable workspace smoke test.
- Tighten workspace dependency declarations to satisfy strict bans (`wildcards = "deny"`) by adding explicit `version` fields on local path dependencies.
- Keep license policy strict (`MIT`/`Apache-2.0`) with minimal targeted exceptions for unavoidable transitive licenses (`unicode-ident` + `foldhash`).

## Why
- Shifts security/compliance checks left so policy violations fail PRs early.
- Uses one policy source of truth (`deny.toml`) instead of split checks.
- Improves supply-chain controls across all execution paths (build, runtime, tests/dev tooling).

## Key Files Changed
- `.github/workflows/ci.yml`
- `.github/workflows/maintenance.yml`
- `deny.toml` (new)
- `Cargo.toml`
- `bench-support/Cargo.toml`

## Test Plan
- [x] `cargo deny check licenses`
- [x] `cargo deny check bans`
- [x] `cargo deny check sources`
- [ ] Verify GitHub Actions pass on PR:
  - [ ] `CI / Cargo Deny`
  - [ ] `Maintenance / Dependency Policy (cargo-deny)` (on schedule/manual run)

## Notes
- `security-audit` behavior is now covered by `cargo-deny` advisories checks.
- Policy is intentionally strict; future third-party additions may require explicit, reviewed exceptions in `deny.toml`.