### PR TITLE
docs: enhance benchmark documentation with value construction convention

### DIFF
--- a/benches/reports.rs
+++ b/benches/reports.rs
@@ -2,6 +2,15 @@
 //!
 //! This is a standalone binary (not a criterion benchmark) that prints
 //! human-readable comparison tables for cache policy evaluation.
+//!
+//! ## Value construction convention
+//!
+//! Benchmark entry points take a `value_for_key: Fn(u64) -> Arc<V>` so callers
+//! choose what to store. We pass [`Arc::new`] directly, which the compiler
+//! resolves to `fn(u64) -> Arc<u64>`, i.e. the value is the key itself wrapped
+//! in `Arc`. Cache-policy measurements (hit/miss, eviction, latency) don't
+//! depend on payload contents, so the cheapest possible payload keeps the
+//! workload focused on policy behavior rather than allocator/clone cost.
 
 use bench_support as common;
 use bench_support::for_each_policy;

--- a/benches/runner.rs
+++ b/benches/runner.rs
@@ -4,6 +4,15 @@
 //! JSON results to `target/benchmarks/<run-id>/results.json`.
 //!
 //! Run with: `cargo bench --bench runner`
+//!
+//! ## Value construction convention
+//!
+//! Benchmark entry points take a `value_for_key: Fn(u64) -> Arc<V>` so callers
+//! choose what to store. We pass [`Arc::new`] directly, which the compiler
+//! resolves to `fn(u64) -> Arc<u64>`, i.e. the value is the key itself wrapped
+//! in `Arc`. Cache-policy measurements (hit/miss, eviction, latency) don't
+//! depend on payload contents, so the cheapest possible payload keeps the
+//! workload focused on policy behavior rather than allocator/clone cost.
 
 use bench_support as common;
 use bench_support::for_each_policy;

--- a/benches/workloads.rs
+++ b/benches/workloads.rs
@@ -11,6 +11,15 @@
 //! For micro-ops (get/insert latency), see: `cargo bench --bench ops`
 //! For policy-specific operations, see: `cargo bench --bench policy_*`
 //! For external crate comparison, see: `cargo bench --bench comparison`
+//!
+//! ## Value construction convention
+//!
+//! Benchmark entry points take a `value_for_key: Fn(u64) -> Arc<V>` so callers
+//! choose what to store. We pass [`Arc::new`] directly, which the compiler
+//! resolves to `fn(u64) -> Arc<u64>`, i.e. the value is the key itself wrapped
+//! in `Arc`. Cache-policy measurements (hit/miss, eviction, latency) don't
+//! depend on payload contents, so the cheapest possible payload keeps the
+//! workload focused on policy behavior rather than allocator/clone cost.
 
 use bench_support as common;
 use bench_support::for_each_policy;


### PR DESCRIPTION
- Added a section on value construction convention to the benchmark files, clarifying how benchmark entry points utilize `Fn(u64) -> Arc<V>` for value storage.
- Emphasized the importance of using the cheapest possible payload to focus on cache policy behavior rather than allocator costs.

These updates improve the clarity of benchmark usage and ensure users understand the implications of value construction on performance metrics.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or modification

## How Has This Been Tested?

<!-- Describe how you tested your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test environment:**
- OS:
- Rust version:

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt` and `cargo clippy`
- [ ] I have added tests for my changes
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation as needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
