### PR TITLE
fix: preserve fetch_update MSRV compatibility

### DIFF
--- a/src/policy/s3_fifo.rs
+++ b/src/policy/s3_fifo.rs
@@ -633,6 +633,8 @@ where
     /// hit/miss counters.
     #[cfg(feature = "concurrency")]
     #[inline]
+    // `try_update` is the nightly name, but `fetch_update` is required by our Rust 1.85 MSRV.
+    #[allow(deprecated)]
     pub(crate) fn get_shared(&self, key: &K) -> Option<&V> {
         let &id = self.map.get(key)?;
         let node = self.arena.get(id).expect("map/arena out of sync");


### PR DESCRIPTION
## Summary
- retain `AtomicU8::fetch_update` for the declared Rust 1.85 MSRV
- narrowly allow its nightly deprecation on `S3Fifo::get_shared`
- document why switching to nightly's `try_update` is not currently possible

## Validation
- `cargo clippy --locked --all-targets --all-features -- -D warnings` (stable 1.97)
- `cargo +nightly check --locked --all-features --tests` (nightly 1.99)
- `cargo check --locked --all-features` (rustc 1.85.0)